### PR TITLE
Conditions UI revamp

### DIFF
--- a/src/Artemis.Core/Models/Profile/Conditions/Abstract/DataModelConditionPart.cs
+++ b/src/Artemis.Core/Models/Profile/Conditions/Abstract/DataModelConditionPart.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using Artemis.Core.Services;
+using System.Collections.ObjectModel;
 using Artemis.Storage.Entities.Profile.Abstract;
 
 namespace Artemis.Core
@@ -20,18 +20,22 @@ namespace Artemis.Core
         /// <summary>
         ///     Gets the children of this part
         /// </summary>
-        public IReadOnlyList<DataModelConditionPart> Children => _children.AsReadOnly();
+        public ReadOnlyCollection<DataModelConditionPart> Children => _children.AsReadOnly();
 
         /// <summary>
         ///     Adds a child to the display condition part's <see cref="Children" /> collection
         /// </summary>
         /// <param name="dataModelConditionPart"></param>
-        public void AddChild(DataModelConditionPart dataModelConditionPart)
+        /// <param name="index">An optional index at which to insert the condition</param>
+        public void AddChild(DataModelConditionPart dataModelConditionPart, int? index = null)
         {
             if (!_children.Contains(dataModelConditionPart))
             {
                 dataModelConditionPart.Parent = this;
-                _children.Add(dataModelConditionPart);
+                if (index != null)
+                    _children.Insert(index.Value, dataModelConditionPart);
+                else
+                    _children.Add(dataModelConditionPart);
             }
         }
 

--- a/src/Artemis.Core/Models/Profile/Conditions/ListPredicateWrapperDataModel.cs
+++ b/src/Artemis.Core/Models/Profile/Conditions/ListPredicateWrapperDataModel.cs
@@ -5,6 +5,7 @@ namespace Artemis.Core
 {
     internal class ListPredicateWrapperDataModel<T> : ListPredicateWrapperDataModel
     {
+        [DataModelProperty(Name = "List item", Description = "The current item in the list")]
         public T Value => (UntypedValue is T typedValue ? typedValue : default)!;
     }
 

--- a/src/Artemis.Core/Models/Profile/DataBindings/Modes/ConditionalDataBinding.cs
+++ b/src/Artemis.Core/Models/Profile/DataBindings/Modes/ConditionalDataBinding.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Linq;
 using Artemis.Storage.Entities.Profile.DataBindings;
 
@@ -25,7 +26,7 @@ namespace Artemis.Core
         /// <summary>
         ///     Gets a list of conditions applied to this data binding
         /// </summary>
-        public IReadOnlyList<DataBindingCondition<TLayerProperty, TProperty>> Conditions => _conditions.AsReadOnly();
+        public ReadOnlyCollection<DataBindingCondition<TLayerProperty, TProperty>> Conditions => _conditions.AsReadOnly();
 
         /// <inheritdoc />
         public DataBinding<TLayerProperty, TProperty> DataBinding { get; }

--- a/src/Artemis.Core/Models/Profile/DataBindings/Modes/DirectDataBinding.cs
+++ b/src/Artemis.Core/Models/Profile/DataBindings/Modes/DirectDataBinding.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using Artemis.Storage.Entities.Profile.DataBindings;
 
 namespace Artemis.Core
@@ -28,7 +29,7 @@ namespace Artemis.Core
         /// <summary>
         ///     Gets a list of modifiers applied to this data binding
         /// </summary>
-        public IReadOnlyList<DataBindingModifier<TLayerProperty, TProperty>> Modifiers => _modifiers.AsReadOnly();
+        public ReadOnlyCollection<DataBindingModifier<TLayerProperty, TProperty>> Modifiers => _modifiers.AsReadOnly();
 
         internal DirectDataBindingEntity Entity { get; }
 

--- a/src/Artemis.Core/Models/Profile/LayerProperties/LayerProperty.cs
+++ b/src/Artemis.Core/Models/Profile/LayerProperties/LayerProperty.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Linq;
 using System.Linq.Expressions;
 using Artemis.Storage.Entities.Profile;
@@ -215,7 +216,7 @@ namespace Artemis.Core
         /// <summary>
         ///     Gets a read-only list of all the keyframes on this layer property
         /// </summary>
-        public IReadOnlyList<LayerPropertyKeyframe<T>> Keyframes => _keyframes.AsReadOnly();
+        public ReadOnlyCollection<LayerPropertyKeyframe<T>> Keyframes => _keyframes.AsReadOnly();
 
         /// <summary>
         ///     Gets the current keyframe in the timeline according to the current progress

--- a/src/Artemis.UI.Shared/DataModelVisualization/Input/DataModelDynamicView.xaml
+++ b/src/Artemis.UI.Shared/DataModelVisualization/Input/DataModelDynamicView.xaml
@@ -6,6 +6,7 @@
              xmlns:shared="clr-namespace:Artemis.UI.Shared"
              xmlns:input="clr-namespace:Artemis.UI.Shared.Input"
              xmlns:s="https://github.com/canton7/Stylet"
+             xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
              mc:Ignorable="d"
              d:DesignHeight="450" d:DesignWidth="800"
              d:DataContext="{d:DesignInstance input:DataModelDynamicViewModel}">
@@ -24,45 +25,71 @@
                             </DataTrigger>
                         </DataTemplate.Triggers>
                     </DataTemplate>
+                    <Style x:Key="DataModelConditionButtonCornerToggle" BasedOn="{StaticResource DataModelConditionButton}" TargetType="Button">
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding DisplaySwitchButton}" Value="True">
+                                <Setter Property="materialDesign:ButtonAssist.CornerRadius" Value="0 2 2 0" />
+                            </DataTrigger>
+                            <DataTrigger Binding="{Binding DisplaySwitchButton}" Value="False">
+                                <Setter Property="materialDesign:ButtonAssist.CornerRadius" Value="2" />
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
                 </ResourceDictionary>
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </UserControl.Resources>
-    <Button Background="{Binding ButtonBrush}"
-            BorderBrush="{Binding ButtonBrush}"
-            Style="{StaticResource DataModelConditionButton}"
-            ToolTip="{Binding DisplayPath}"
-            IsEnabled="{Binding IsEnabled}"
-            HorizontalAlignment="Left"
-            Click="PropertyButton_OnClick">
-        <Button.ContextMenu>
-            <ContextMenu ItemsSource="{Binding DataModelViewModel.Children}" IsOpen="{Binding IsDataModelViewModelOpen, Mode=OneWayToSource}">
-                <ContextMenu.ItemContainerStyle>
-                    <Style TargetType="{x:Type MenuItem}" BasedOn="{StaticResource MaterialDesignMenuItem}">
-                        <Setter Property="ItemsSource" Value="{Binding Children}" />
-                        <Setter Property="Command" Value="{Binding Data.SelectPropertyCommand, Source={StaticResource DataContextProxy}}" />
-                        <Setter Property="CommandParameter" Value="{Binding}" />
-                        <Setter Property="CommandTarget" Value="{Binding}" />
-                        <Setter Property="IsEnabled" Value="{Binding IsMatchingFilteredTypes}" />
-                        <Setter Property="IsSubmenuOpen" Value="{Binding IsVisualizationExpanded, Mode=TwoWay}" />
-                        <Setter Property="HeaderTemplate" Value="{StaticResource DataModelDataTemplate}" />
-                    </Style>
-                </ContextMenu.ItemContainerStyle>
-            </ContextMenu>
-        </Button.ContextMenu>
-        <Grid>
-            <Grid Visibility="{Binding IsValid,Converter={x:Static s:BoolToVisibilityConverter.Instance}, Mode=OneWay}">
-                <TextBlock Text="{Binding DisplayValue}"
-                           Visibility="{Binding DataModelPath, Converter={StaticResource NullToVisibilityConverter}}" />
+    <StackPanel Orientation="Horizontal">
+        <Button Style="{StaticResource MaterialDesignFlatDarkBgButton}"
+                Height="22"
+                Padding="0"
+                Width="22"
+                FontSize="12"
+                materialDesign:ButtonAssist.CornerRadius="2 0 0 2"
+                Margin="3 0 -3 0"
+                HorizontalAlignment="Left"
+                ToolTip="Switch to manual input"
+                Command="{s:Action SwitchToStatic}"
+                Visibility="{Binding DisplaySwitchButton, Converter={x:Static s:BoolToVisibilityConverter.Instance}, Mode=OneWay}">
+            <materialDesign:PackIcon Kind="SwapHorizontal" />
+        </Button>
+        <Button Background="{Binding ButtonBrush}"
+                BorderBrush="{Binding ButtonBrush}"
+                Style="{StaticResource DataModelConditionButtonCornerToggle}"
+                ToolTip="{Binding DisplayPath}"
+                IsEnabled="{Binding IsEnabled}"
+                HorizontalAlignment="Left"
+                Click="PropertyButton_OnClick">
+            <Button.ContextMenu>
+                <ContextMenu ItemsSource="{Binding DataModelViewModel.Children}" IsOpen="{Binding IsDataModelViewModelOpen, Mode=OneWayToSource}">
+                    <ContextMenu.ItemContainerStyle>
+                        <Style TargetType="{x:Type MenuItem}" BasedOn="{StaticResource MaterialDesignMenuItem}">
+                            <Setter Property="ItemsSource" Value="{Binding Children}" />
+                            <Setter Property="Command" Value="{Binding Data.SelectPropertyCommand, Source={StaticResource DataContextProxy}}" />
+                            <Setter Property="CommandParameter" Value="{Binding}" />
+                            <Setter Property="CommandTarget" Value="{Binding}" />
+                            <Setter Property="IsEnabled" Value="{Binding IsMatchingFilteredTypes}" />
+                            <Setter Property="IsSubmenuOpen" Value="{Binding IsVisualizationExpanded, Mode=TwoWay}" />
+                            <Setter Property="HeaderTemplate" Value="{StaticResource DataModelDataTemplate}" />
+                        </Style>
+                    </ContextMenu.ItemContainerStyle>
+                </ContextMenu>
+            </Button.ContextMenu>
+            <Grid>
+                <Grid Visibility="{Binding IsValid,Converter={x:Static s:BoolToVisibilityConverter.Instance}, Mode=OneWay}">
+                    <TextBlock Text="{Binding DisplayValue}"
+                               Visibility="{Binding DataModelPath, Converter={StaticResource NullToVisibilityConverter}}" />
+                    <TextBlock FontStyle="Italic"
+                               Visibility="{Binding DataModelPath, Converter={StaticResource NullToVisibilityConverter}, ConverterParameter=Inverted}">
+                        <Run Text="« " /><Run Text="{Binding Placeholder}" /><Run Text=" »" />
+                    </TextBlock>
+                </Grid>
                 <TextBlock FontStyle="Italic"
-                           Visibility="{Binding DataModelPath, Converter={StaticResource NullToVisibilityConverter}, ConverterParameter=Inverted}">
-                    <Run Text="« " /><Run Text="{Binding Placeholder}" /><Run Text=" »" />
+                           Visibility="{Binding IsValid, Converter={x:Static s:BoolToVisibilityConverter.InverseInstance}, Mode=OneWay}">
+                    « Invalid »
                 </TextBlock>
             </Grid>
-            <TextBlock FontStyle="Italic"
-                       Visibility="{Binding IsValid, Converter={x:Static s:BoolToVisibilityConverter.InverseInstance}, Mode=OneWay}">
-                « Invalid »
-            </TextBlock>
-        </Grid>
-    </Button>
+        </Button>
+    </StackPanel>
+
 </UserControl>

--- a/src/Artemis.UI.Shared/DataModelVisualization/Input/DataModelDynamicView.xaml
+++ b/src/Artemis.UI.Shared/DataModelVisualization/Input/DataModelDynamicView.xaml
@@ -61,8 +61,8 @@
                 HorizontalAlignment="Left"
                 Click="PropertyButton_OnClick">
             <Button.ContextMenu>
-                <ContextMenu ItemsSource="{Binding DataModelViewModel.Children}" IsOpen="{Binding IsDataModelViewModelOpen, Mode=OneWayToSource}">
-                    <ContextMenu.ItemContainerStyle>
+                <ContextMenu IsOpen="{Binding IsDataModelViewModelOpen, Mode=OneWayToSource}">
+                    <ContextMenu.Resources>
                         <Style TargetType="{x:Type MenuItem}" BasedOn="{StaticResource MaterialDesignMenuItem}">
                             <Setter Property="ItemsSource" Value="{Binding Children}" />
                             <Setter Property="Command" Value="{Binding Data.SelectPropertyCommand, Source={StaticResource DataContextProxy}}" />
@@ -72,7 +72,14 @@
                             <Setter Property="IsSubmenuOpen" Value="{Binding IsVisualizationExpanded, Mode=TwoWay}" />
                             <Setter Property="HeaderTemplate" Value="{StaticResource DataModelDataTemplate}" />
                         </Style>
-                    </ContextMenu.ItemContainerStyle>
+                    </ContextMenu.Resources>
+                    <ContextMenu.ItemsSource>
+                        <CompositeCollection>
+                            <CollectionContainer Collection="{Binding Data.ExtraDataModelViewModels, Source={StaticResource DataContextProxy}}" />
+                            <Separator Visibility="{Binding Data.HasExtraDataModels, Source={StaticResource DataContextProxy}, Converter={x:Static s:BoolToVisibilityConverter.Instance}, Mode=OneWay}"/>
+                            <CollectionContainer Collection="{Binding Data.DataModelViewModel.Children, Source={StaticResource DataContextProxy}}" />
+                        </CompositeCollection>
+                    </ContextMenu.ItemsSource>
                 </ContextMenu>
             </Button.ContextMenu>
             <Grid>

--- a/src/Artemis.UI.Shared/DataModelVisualization/Input/DataModelDynamicViewModel.cs
+++ b/src/Artemis.UI.Shared/DataModelVisualization/Input/DataModelDynamicViewModel.cs
@@ -25,6 +25,7 @@ namespace Artemis.UI.Shared.Input
         private bool _isDataModelViewModelOpen;
         private bool _isEnabled = true;
         private string _placeholder = "Select a property";
+        private bool _displaySwitchButton;
 
         internal DataModelDynamicViewModel(Module module, ISettingsService settingsService, IDataModelUIService dataModelUIService)
         {
@@ -54,6 +55,12 @@ namespace Artemis.UI.Shared.Input
         {
             get => _isEnabled;
             set => SetAndNotify(ref _isEnabled, value);
+        }
+
+        public bool DisplaySwitchButton
+        {
+            get => _displaySwitchButton;
+            set => SetAndNotify(ref _displaySwitchButton, value);
         }
 
         public Type[] FilterTypes
@@ -125,6 +132,13 @@ namespace Artemis.UI.Shared.Input
             DataModelPath = dataModelPath != null ? new DataModelPath(dataModelPath) : null;
         }
 
+        public void SwitchToStatic()
+        {
+            ChangeDataModelPath(null);
+            OnPropertySelected(new DataModelInputDynamicEventArgs(null));
+            OnSwitchToStaticRequested();
+        }
+
         private void Initialize()
         {
             // Get the data models
@@ -167,10 +181,16 @@ namespace Artemis.UI.Shared.Input
         #region Events
 
         public event EventHandler<DataModelInputDynamicEventArgs> PropertySelected;
+        public event EventHandler SwitchToStaticRequested;
 
         protected virtual void OnPropertySelected(DataModelInputDynamicEventArgs e)
         {
             PropertySelected?.Invoke(this, e);
+        }
+
+        protected virtual void OnSwitchToStaticRequested()
+        {
+            SwitchToStaticRequested?.Invoke(this, EventArgs.Empty);
         }
 
         #endregion

--- a/src/Artemis.UI.Shared/DataModelVisualization/Input/DataModelStaticView.xaml
+++ b/src/Artemis.UI.Shared/DataModelVisualization/Input/DataModelStaticView.xaml
@@ -22,24 +22,39 @@
     </UserControl.Resources>
 
     <Grid Margin="3 -4">
-        <Button Style="{StaticResource DataModelConditionButton}"
-                Background="{Binding ButtonBrush}"
-                BorderBrush="{Binding ButtonBrush}"
-                Margin="0 4"
-                Command="{s:Action ActivateInputViewModel}"
-                HorizontalAlignment="Left"
-                IsEnabled="{Binding IsEnabled}"
-                Visibility="{Binding InputViewModel, Converter={StaticResource NullToVisibilityConverter}, ConverterParameter=Inverted}">
-            <Grid>
-                <StackPanel Visibility="{Binding Value, Converter={StaticResource NullToVisibilityConverter}}" Orientation="Horizontal">
-                    <ContentControl s:View.Model="{Binding DisplayViewModel}" VerticalAlignment="Stretch" HorizontalAlignment="Stretch" />
-                </StackPanel>
+        <StackPanel Orientation="Horizontal" Visibility="{Binding InputViewModel, Converter={StaticResource NullToVisibilityConverter}, ConverterParameter=Inverted}">
+            <Button Style="{StaticResource MaterialDesignFlatDarkBgButton}"
+                    Height="22"
+                    Padding="0"
+                    Width="22"
+                    FontSize="12"
+                    materialDesign:ButtonAssist.CornerRadius="2 0 0 2"
+                    Margin="0 0 -3 0"
+                    HorizontalAlignment="Left"
+                    ToolTip="Switch to data model value"
+                    Command="{s:Action SwitchToDynamic}">
+                <materialDesign:PackIcon Kind="SwapHorizontal" />
+            </Button>
+            <Button Style="{StaticResource DataModelConditionButton}"
+                    materialDesign:ButtonAssist.CornerRadius="0 2 2 0"
+                    Background="{Binding ButtonBrush}"
+                    BorderBrush="{Binding ButtonBrush}"
+                    Command="{s:Action ActivateInputViewModel}"
+                    HorizontalAlignment="Left"
+                    IsEnabled="{Binding IsEnabled}"
+                    ToolTip="Click to edit value">
+                <Grid>
+                    <StackPanel Visibility="{Binding Value, Converter={StaticResource NullToVisibilityConverter}}" Orientation="Horizontal">
+                        <ContentControl s:View.Model="{Binding DisplayViewModel}" VerticalAlignment="Stretch" HorizontalAlignment="Stretch" />
+                    </StackPanel>
 
-                <TextBlock FontStyle="Italic" Visibility="{Binding Value, Converter={StaticResource NullToVisibilityConverter}, ConverterParameter=Inverted}">
-                    <Run Text="« " /><Run Text="{Binding Placeholder}" /><Run Text=" »" />
-                </TextBlock>
-            </Grid>
-        </Button>
+                    <TextBlock FontStyle="Italic" Visibility="{Binding Value, Converter={StaticResource NullToVisibilityConverter}, ConverterParameter=Inverted}">
+                        <Run Text="« " /><Run Text="{Binding Placeholder}" /><Run Text=" »" />
+                    </TextBlock>
+                </Grid>
+            </Button>
+        </StackPanel>
+        
         <Border BorderBrush="{Binding ButtonBrush}"
                 Background="{DynamicResource MaterialDesignPaper}"
                 Visibility="{Binding InputViewModel, Converter={StaticResource NullToVisibilityConverter}}"

--- a/src/Artemis.UI.Shared/Services/Interfaces/IProfileEditorService.cs
+++ b/src/Artemis.UI.Shared/Services/Interfaces/IProfileEditorService.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using Artemis.Core;
 using Artemis.Core.Modules;
 using Ninject;
@@ -13,7 +14,7 @@ namespace Artemis.UI.Shared.Services
         ILayerProperty SelectedDataBinding { get; }
         TimeSpan CurrentTime { get; set; }
         int PixelsPerSecond { get; set; }
-        IReadOnlyList<PropertyInputRegistration> RegisteredPropertyEditors { get; }
+        ReadOnlyCollection<PropertyInputRegistration> RegisteredPropertyEditors { get; }
         IKernel Kernel { get; }
         void ChangeSelectedProfile(Profile profile);
         void UpdateSelectedProfile();

--- a/src/Artemis.UI.Shared/Services/ProfileEditorService.cs
+++ b/src/Artemis.UI.Shared/Services/ProfileEditorService.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Linq;
 using Artemis.Core;
 using Artemis.Core.Modules;
@@ -32,7 +33,7 @@ namespace Artemis.UI.Shared.Services
         }
 
         public IKernel Kernel { get; }
-        public IReadOnlyList<PropertyInputRegistration> RegisteredPropertyEditors => _registeredPropertyEditors.AsReadOnly();
+        public ReadOnlyCollection<PropertyInputRegistration> RegisteredPropertyEditors => _registeredPropertyEditors.AsReadOnly();
         public Profile SelectedProfile { get; private set; }
         public RenderProfileElement SelectedProfileElement { get; private set; }
         public ILayerProperty SelectedDataBinding { get; private set; }

--- a/src/Artemis.UI/Screens/ProfileEditor/Conditions/DataModelConditionGroupView.xaml
+++ b/src/Artemis.UI/Screens/ProfileEditor/Conditions/DataModelConditionGroupView.xaml
@@ -98,42 +98,9 @@
             </Button.Style>
             <Button.ContextMenu>
                 <ContextMenu>
-                    <ContextMenu.Resources>
-                        <Converters:InverseBooleanConverter x:Key="InverseBooleanConverter" />
-                    </ContextMenu.Resources>
-                    <MenuItem Header="Add static condition"
-                              ToolTip="A condition that compares with a static input"
-                              Command="{s:Action AddCondition}"
-                              CommandParameter="Static">
+                    <MenuItem Header="Add condition" ToolTip="A condition that compares with another value" Command="{s:Action AddCondition}">
                         <MenuItem.Icon>
-                            <materialDesign:PackIcon Kind="FormTextarea" />
-                        </MenuItem.Icon>
-                    </MenuItem>
-                    <MenuItem Header="Add dynamic condition"
-                              ToolTip="A condition that compares with a data model property"
-                              Command="{s:Action AddCondition}"
-                              CommandParameter="Dynamic">
-                        <MenuItem.Icon>
-                            <materialDesign:PackIcon Kind="Link" />
-                        </MenuItem.Icon>
-                    </MenuItem>
-                    <MenuItem Header="Add self condition"
-                              ToolTip="A condition that compares with a property contained in the list"
-                              Command="{s:Action AddCondition}"
-                              CommandParameter="DynamicList"
-                              IsEnabled="{Binding Data.DynamicListConditionSupported, Source={StaticResource DataContextProxy}}"
-                              Visibility="{Binding Data.IsListGroup, Converter={x:Static s:BoolToVisibilityConverter.Instance}, Source={StaticResource DataContextProxy}}">
-                        <MenuItem.Icon>
-                            <materialDesign:PackIcon Kind="UndoVariant" />
-                        </MenuItem.Icon>
-                    </MenuItem>
-                    <MenuItem Header="Add list condition"
-                              ToolTip="A condition that evaluates on items in a list"
-                              Command="{s:Action AddCondition}"
-                              CommandParameter="List"
-                              Visibility="{Binding Data.IsListGroup, Converter={x:Static s:BoolToVisibilityConverter.InverseInstance}, Source={StaticResource DataContextProxy}}">
-                        <MenuItem.Icon>
-                            <materialDesign:PackIcon Kind="FormatListBulleted" />
+                            <materialDesign:PackIcon Kind="Equal" />
                         </MenuItem.Icon>
                     </MenuItem>
                     <MenuItem Header="Add group" ToolTip="A group can contain conditions and other groups" Command="{s:Action AddGroup}">

--- a/src/Artemis.UI/Screens/ProfileEditor/Conditions/DataModelConditionListPredicateViewModel.cs
+++ b/src/Artemis.UI/Screens/ProfileEditor/Conditions/DataModelConditionListPredicateViewModel.cs
@@ -87,7 +87,7 @@ namespace Artemis.UI.Screens.ProfileEditor.Conditions
 
         public void Initialize()
         {
-            DataModelVisualizationViewModel listDataModel = GetListDataModel();
+            DataModelPropertiesViewModel listDataModel = GetListDataModel();
             if (listDataModel.Children.Count == 1 && listDataModel.Children.First() is DataModelListPropertyViewModel)
                 _isPrimitiveList = true;
             else
@@ -97,7 +97,7 @@ namespace Artemis.UI.Screens.ProfileEditor.Conditions
             if (!_isPrimitiveList)
             {
                 LeftSideSelectionViewModel = _dataModelUIService.GetDynamicSelectionViewModel(_profileEditorService.GetCurrentModule());
-                LeftSideSelectionViewModel.ChangeDataModel((DataModelPropertiesViewModel) listDataModel);
+                LeftSideSelectionViewModel.ChangeDataModel(listDataModel);
                 LeftSideSelectionViewModel.PropertySelected += LeftSideOnPropertySelected;
             }
 
@@ -194,7 +194,7 @@ namespace Artemis.UI.Screens.ProfileEditor.Conditions
             Update();
         }
 
-        private DataModelVisualizationViewModel GetListDataModel()
+        private DataModelPropertiesViewModel GetListDataModel()
         {
             if (DataModelConditionListPredicate.DataModelConditionList.ListPath?.DataModelGuid == null)
                 throw new ArtemisUIException("Failed to retrieve the list data model VM for this list predicate because it has no list path");
@@ -273,6 +273,11 @@ namespace Artemis.UI.Screens.ProfileEditor.Conditions
             RightSideSelectionViewModel.DisplaySwitchButton = true;
             RightSideSelectionViewModel.PropertySelected += RightSideOnPropertySelected;
             RightSideSelectionViewModel.SwitchToStaticRequested += RightSideSelectionViewModelOnSwitchToStaticRequested;
+
+            // Add an extra data model to the selection VM to allow self-referencing the current item
+            // The safe cast prevents adding this extra VM on primitive lists where they serve no purpose
+            if (GetListDataModel()?.Children?.FirstOrDefault() is DataModelPropertiesViewModel listValue) 
+                RightSideSelectionViewModel.ExtraDataModelViewModels.Add(listValue);
         }
 
         private void CreateRightSideInputViewModel(Type leftSideType)

--- a/src/Artemis.UI/Screens/ProfileEditor/LayerProperties/DataBindings/ConditionalDataBinding/ConditionalDataBindingModeViewModel.cs
+++ b/src/Artemis.UI/Screens/ProfileEditor/LayerProperties/DataBindings/ConditionalDataBinding/ConditionalDataBindingModeViewModel.cs
@@ -56,17 +56,6 @@ namespace Artemis.UI.Screens.ProfileEditor.LayerProperties.DataBindings.Conditio
 
         #endregion
 
-        public void AddCondition(string type)
-        {
-            DataBindingCondition<TLayerProperty, TProperty> condition = ConditionalDataBinding.AddCondition();
-
-            // Find the VM of the new condition
-            DataBindingConditionViewModel<TLayerProperty, TProperty> viewModel = ConditionViewModels.First(c => c.DataBindingCondition == condition);
-            viewModel.ActiveItem.AddCondition(type);
-
-            _profileEditorService.UpdateSelectedProfileElement();
-        }
-
         private void UpdateConditionViewModels()
         {
             _updating = true;

--- a/src/Artemis.UI/Screens/RootView.xaml
+++ b/src/Artemis.UI/Screens/RootView.xaml
@@ -57,7 +57,7 @@
 
         <materialDesign:DrawerHost IsLeftDrawerOpen="{Binding SidebarViewModel.IsSidebarOpen}">
             <materialDesign:DrawerHost.LeftDrawerContent>
-                <ContentControl s:View.Model="{Binding SidebarViewModel}" Width="220" ClipToBounds="False" />
+                <ContentControl s:View.Model="{Binding SidebarViewModel}" Width="280" ClipToBounds="False" />
             </materialDesign:DrawerHost.LeftDrawerContent>
             <DockPanel>
                 <mde:AppBar Type="Dense"

--- a/src/Artemis.UI/Screens/Sidebar/SidebarView.xaml
+++ b/src/Artemis.UI/Screens/Sidebar/SidebarView.xaml
@@ -12,17 +12,29 @@
              d:DataContext="{d:DesignInstance sidebar:SidebarViewModel}">
     <Grid>
         <Grid.RowDefinitions>
-            <!-- no idea why this has to be 0 -->
-            <RowDefinition Height="0" />
+            <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
 
-        <Image Grid.Row="0" Grid.RowSpan="2" Source="/Resources/Images/Sidebar/sidebar-header.png" Stretch="Uniform" VerticalAlignment="Top" />
-        <TextBlock Grid.Row="1" Style="{StaticResource MaterialDesignHeadline6TextBlock}" Margin="15" materialDesign:ShadowAssist.ShadowDepth="Depth1" Text="{Binding ActiveModules}" />
+        <Image Grid.Row="0"
+               Grid.RowSpan="2"
+               Source="/Resources/Images/Sidebar/sidebar-header.png"
+               Stretch="None"
+               VerticalAlignment="Top" Height="120" />
+        <TextBlock Grid.Row="1"
+                   Style="{StaticResource MaterialDesignHeadline6TextBlock}"
+                   Margin="15"
+                   materialDesign:ShadowAssist.ShadowDepth="Depth1"
+                   Text="{Binding ActiveModules}"
+                   VerticalAlignment="Bottom" />
 
-        <controls:SideNavigation Grid.Row="3" Items="{Binding SidebarItems}" SelectedItem="{Binding SelectedItem}" WillSelectNavigationItemCommand="{s:Action SelectItem}" Margin="0 5 0 0" />
+        <controls:SideNavigation Grid.Row="3"
+                                 Items="{Binding SidebarItems}"
+                                 SelectedItem="{Binding SelectedItem}"
+                                 WillSelectNavigationItemCommand="{s:Action SelectItem}"
+                                 Margin="0 5 0 0" />
     </Grid>
 
 </UserControl>


### PR DESCRIPTION
Redid the way condition types are selected to be more reactive to user input and less dependent on early choices.

- Ditched the different kinds of conditions under the + sign, you can now only add conditions and groups
- Switching a condition between static and dynamic (now just called manual and data model) is done with a button
- List-conditions are created by simply selecting a list, it will convert automatically 
- A list-condition can convert back to a regular condition in the same way
- Events will work similarly, if you select an event you create an event-condition
- List-conditions have an extra entry in the data model for self referencing