### PR TITLE
Fixed an AccessViolationException when moving devices in the surface

### DIFF
--- a/src/Artemis.UI/Screens/Settings/Debug/Tabs/RenderDebugViewModel.cs
+++ b/src/Artemis.UI/Screens/Settings/Debug/Tabs/RenderDebugViewModel.cs
@@ -55,7 +55,11 @@ namespace Artemis.UI.Screens.Settings.Debug.Tabs
                 if (e.BitmapBrush?.Bitmap == null || e.BitmapBrush.Bitmap.Pixels.Length == 0)
                     return;
 
-                if (!(CurrentFrame is WriteableBitmap writeableBitmap))
+                var bitmapInfo = e.BitmapBrush.Bitmap.Info;
+
+                if (!(CurrentFrame is WriteableBitmap writeableBitmap) || 
+                    writeableBitmap.Width != bitmapInfo.Width || 
+                    writeableBitmap.Height != bitmapInfo.Height)
                 {
                     CurrentFrame = e.BitmapBrush.Bitmap.ToWriteableBitmap();
                     return;


### PR DESCRIPTION
Fixes a crash that can happen when the user either moves a device in the surface or changes surface configurations. Checking if the bitmap size changed every tick seems to be fast enough and protects against this better than using the SurfaceService events.


Feel free to change formatting.