### PR TITLE
Added Per device color calibration

### DIFF
--- a/src/Artemis.Core/Models/Surface/ArtemisDevice.cs
+++ b/src/Artemis.Core/Models/Surface/ArtemisDevice.cs
@@ -174,6 +174,9 @@ namespace Artemis.Core
             }
         }
 
+        /// <summary>
+        ///     Gets or sets the scale of the red color component used for calibration
+        /// </summary>
         public double RedScale
         {
             get => DeviceEntity.RedScale;
@@ -184,6 +187,9 @@ namespace Artemis.Core
             }
         }
 
+        /// <summary>
+        ///     Gets or sets the scale of the green color component used for calibration
+        /// </summary>
         public double GreenScale
         {
             get => DeviceEntity.GreenScale;
@@ -194,6 +200,9 @@ namespace Artemis.Core
             }
         }
 
+        /// <summary>
+        ///     Gets or sets the scale of the blue color component used for calibration
+        /// </summary>
         public double BlueScale
         {
             get => DeviceEntity.BlueScale;

--- a/src/Artemis.Core/Models/Surface/ArtemisDevice.cs
+++ b/src/Artemis.Core/Models/Surface/ArtemisDevice.cs
@@ -27,6 +27,9 @@ namespace Artemis.Core
             Rotation = 0;
             Scale = 1;
             ZIndex = 1;
+            RedScale = 1;
+            GreenScale = 1;
+            BlueScale = 1;
 
             deviceProvider.DeviceLayoutPaths.TryGetValue(rgbDevice, out string? layoutPath);
             LayoutPath = layoutPath;
@@ -168,6 +171,36 @@ namespace Artemis.Core
             {
                 DeviceEntity.ZIndex = value;
                 OnPropertyChanged(nameof(ZIndex));
+            }
+        }
+
+        public double RedScale
+        {
+            get => DeviceEntity.RedScale;
+            set
+            {
+                DeviceEntity.RedScale = value;
+                OnPropertyChanged(nameof(RedScale));
+            }
+        }
+
+        public double GreenScale
+        {
+            get => DeviceEntity.GreenScale;
+            set
+            {
+                DeviceEntity.GreenScale = value;
+                OnPropertyChanged(nameof(GreenScale));
+            }
+        }
+
+        public double BlueScale
+        {
+            get => DeviceEntity.BlueScale;
+            set
+            {
+                DeviceEntity.BlueScale = value;
+                OnPropertyChanged(nameof(BlueScale));
             }
         }
 

--- a/src/Artemis.Core/Models/Surface/ArtemisLed.cs
+++ b/src/Artemis.Core/Models/Surface/ArtemisLed.cs
@@ -68,5 +68,14 @@ namespace Artemis.Core
         {
             return RgbLed.ToString();
         }
+
+        /// <summary>
+        ///     Gets the color of this led, reverting the correction done to the parent device
+        /// </summary>
+        /// <returns></returns>
+        public Color GetOriginalColor()
+        {
+            return RgbLed.Color.DivideRGB(Device.RedScale, Device.GreenScale, Device.BlueScale);
+        }
     }
 }

--- a/src/Artemis.Core/RGB.NET/BitmapBrush.cs
+++ b/src/Artemis.Core/RGB.NET/BitmapBrush.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using RGB.NET.Core;
 using SkiaSharp;
@@ -101,7 +101,13 @@ namespace Artemis.Core
             {
                 Point scaledLocation = renderTarget.Point * Scale;
                 if (scaledLocation.X < Bitmap.Width && scaledLocation.Y < Bitmap.Height)
-                    RenderedTargets[renderTarget] = Bitmap.GetPixel(scaledLocation.X.RoundToInt(), scaledLocation.Y.RoundToInt()).ToRgbColor();
+                {
+                    var pixel = Bitmap.GetPixel(scaledLocation.X.RoundToInt(), scaledLocation.Y.RoundToInt()).ToRgbColor();
+                    var artemisDevice = Surface?.GetArtemisLed(renderTarget.Led)?.Device;
+                    if (artemisDevice is not null)
+                        pixel = pixel.MultiplyRGB(artemisDevice.RedScale, artemisDevice.GreenScale, artemisDevice.BlueScale);
+                    RenderedTargets[renderTarget] = pixel;
+                }
             }
         }
 
@@ -148,8 +154,13 @@ namespace Artemis.Core
                         // Bitmap.SetPixel(x, y, new SKColor(0, 255, 0));
                     }
                 }
+                var pixel = new Color(a / sampleSize, r / sampleSize, g / sampleSize, b / sampleSize);
 
-                RenderedTargets[renderTarget] = new Color(a / sampleSize, r / sampleSize, g / sampleSize, b / sampleSize);
+                var artemisDevice = Surface?.GetArtemisLed(renderTarget.Led)?.Device;
+                if (artemisDevice is not null)
+                    pixel = pixel.MultiplyRGB(artemisDevice.RedScale, artemisDevice.GreenScale, artemisDevice.BlueScale);
+  
+                RenderedTargets[renderTarget] = pixel;
             }
         }
 

--- a/src/Artemis.Storage/Entities/Surface/DeviceEntity.cs
+++ b/src/Artemis.Storage/Entities/Surface/DeviceEntity.cs
@@ -15,6 +15,9 @@ namespace Artemis.Storage.Entities.Surface
         public double Rotation { get; set; }
         public double Scale { get; set; }
         public int ZIndex { get; set; }
+        public double RedScale { get; set; }
+        public double GreenScale { get; set; }
+        public double BlueScale { get; set; }
 
         public List<DeviceInputIdentifierEntity> InputIdentifiers { get; set; }
     }

--- a/src/Artemis.Storage/Migrations/M9DeviceCalibration.cs
+++ b/src/Artemis.Storage/Migrations/M9DeviceCalibration.cs
@@ -1,0 +1,27 @@
+﻿using Artemis.Storage.Migrations.Interfaces;
+using LiteDB;
+
+namespace Artemis.Storage.Migrations
+{
+    public class M9DeviceCalibration : IStorageMigration
+    {
+        public int UserVersion => 9;
+
+        /// <inheritdoc />
+        public void Apply(LiteRepository repository)
+        {
+            ILiteCollection<BsonDocument> collection = repository.Database.GetCollection("SurfaceEntity");
+            foreach (BsonDocument bsonDocument in collection.FindAll())
+            {
+                foreach (BsonValue bsonDevice in bsonDocument["DeviceEntities"].AsArray)
+                {
+                    bsonDevice["RedScale"] = 1;
+                    bsonDevice["GreenScale"] = 1;
+                    bsonDevice["BlueScale"] = 1;
+                }
+
+                collection.Update(bsonDocument);
+            }
+        }
+    }
+}

--- a/src/Artemis.Storage/Migrations/M9DeviceCalibration.cs
+++ b/src/Artemis.Storage/Migrations/M9DeviceCalibration.cs
@@ -1,4 +1,4 @@
-﻿using Artemis.Storage.Migrations.Interfaces;
+using Artemis.Storage.Migrations.Interfaces;
 using LiteDB;
 
 namespace Artemis.Storage.Migrations
@@ -15,9 +15,9 @@ namespace Artemis.Storage.Migrations
             {
                 foreach (BsonValue bsonDevice in bsonDocument["DeviceEntities"].AsArray)
                 {
-                    bsonDevice["RedScale"] = 1;
-                    bsonDevice["GreenScale"] = 1;
-                    bsonDevice["BlueScale"] = 1;
+                    bsonDevice["RedScale"] = 1d;
+                    bsonDevice["GreenScale"] = 1d;
+                    bsonDevice["BlueScale"] = 1d;
                 }
 
                 collection.Update(bsonDocument);

--- a/src/Artemis.UI.Shared/Controls/DeviceVisualizerLed.cs
+++ b/src/Artemis.UI.Shared/Controls/DeviceVisualizerLed.cs
@@ -38,7 +38,7 @@ namespace Artemis.UI.Shared
             if (DisplayGeometry == null)
                 return;
 
-            RGB.NET.Core.Color originalColor = Led.RgbLed.Color.DivideRGB(Led.Device.RedScale, Led.Device.GreenScale, Led.Device.BlueScale);
+            RGB.NET.Core.Color originalColor = Led.GetOriginalColor();
             byte r = originalColor.GetR();
             byte g = originalColor.GetG();
             byte b = originalColor.GetB();

--- a/src/Artemis.UI.Shared/Controls/DeviceVisualizerLed.cs
+++ b/src/Artemis.UI.Shared/Controls/DeviceVisualizerLed.cs
@@ -38,9 +38,10 @@ namespace Artemis.UI.Shared
             if (DisplayGeometry == null)
                 return;
 
-            byte r = Led.RgbLed.Color.GetR();
-            byte g = Led.RgbLed.Color.GetG();
-            byte b = Led.RgbLed.Color.GetB();
+            RGB.NET.Core.Color originalColor = Led.RgbLed.Color.DivideRGB(Led.Device.RedScale, Led.Device.GreenScale, Led.Device.BlueScale);
+            byte r = originalColor.GetR();
+            byte g = originalColor.GetG();
+            byte b = originalColor.GetB();
 
             drawingContext.DrawRectangle(isDimmed
                 ? new SolidColorBrush(Color.FromArgb(100, r, g, b))

--- a/src/Artemis.UI/Screens/SurfaceEditor/Dialogs/SurfaceDeviceConfigView.xaml
+++ b/src/Artemis.UI/Screens/SurfaceEditor/Dialogs/SurfaceDeviceConfigView.xaml
@@ -12,102 +12,131 @@
     <UserControl.Resources>
         <shared:SKColorToColorConverter x:Key="SKColorToColorConverter" />
     </UserControl.Resources>
-    <StackPanel Margin="16">
-        <TextBlock Text="{Binding Title}"
-                   Style="{StaticResource MaterialDesignHeadline6TextBlock}" />
-        <TextBlock Text="Note: These are not being validated yet"
-                   Style="{StaticResource MaterialDesignSubtitle1TextBlock}" />
+    <StackPanel Margin="16" Width="400">
+        <!-- Title -->
+        <TextBlock Text="{Binding Device.RgbDevice.DeviceInfo.DeviceName}" Style="{StaticResource MaterialDesignHeadline6TextBlock}" />
+        
+        <!-- Body -->
+        <Grid Margin="0 25 0 0">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="2*" />
+                <ColumnDefinition Width="40" />
+                <ColumnDefinition Width="3*" />
+            </Grid.ColumnDefinitions>
 
-        <StackPanel Orientation="Horizontal">
-            <StackPanel Orientation="Vertical"
-                        Width="150"
-                        Margin="8">
+            <!-- Left side -->
+            <StackPanel Grid.Column="0" Orientation="Vertical">
+                <TextBlock Style="{StaticResource MaterialDesignSubtitle1TextBlock}">
+                    Properties
+                </TextBlock>
+
                 <TextBox materialDesign:HintAssist.Hint="X-coordinate"
                          materialDesign:TextFieldAssist.SuffixText="mm"
                          Text="{Binding X, UpdateSourceTrigger=PropertyChanged}"
                          Style="{StaticResource MaterialDesignFloatingHintTextBox}"
-                         Margin="0 10" />
+                         Margin="0 5" />
                 <TextBox materialDesign:HintAssist.Hint="Y-coordinate"
                          materialDesign:TextFieldAssist.SuffixText="mm"
                          Text="{Binding Y, UpdateSourceTrigger=PropertyChanged}"
                          Style="{StaticResource MaterialDesignFloatingHintTextBox}"
-                         Margin="0 10" />
+                         Margin="0 5" />
                 <TextBox materialDesign:HintAssist.Hint="Scale"
                          materialDesign:TextFieldAssist.SuffixText="times"
                          Text="{Binding Scale, UpdateSourceTrigger=PropertyChanged}"
                          Style="{StaticResource MaterialDesignFloatingHintTextBox}"
-                         Margin="0 10" />
+                         Margin="0 5" />
                 <TextBox materialDesign:HintAssist.Hint="Rotation"
                          materialDesign:TextFieldAssist.SuffixText="deg"
                          Text="{Binding Rotation, UpdateSourceTrigger=PropertyChanged}"
                          Style="{StaticResource MaterialDesignFloatingHintTextBox}"
-                         Margin="0 10" />
+                         Margin="0 5 0 12" />
             </StackPanel>
-            <StackPanel Orientation="Vertical"
-                        Width="250"
-                        Margin="8">
-                <Grid>
+
+            <!-- Center divider -->
+            <Rectangle Grid.Column="1" VerticalAlignment="Stretch" Fill="{StaticResource MaterialDesignTextBoxBorder}" Width="1" Margin="0 0 0 5" />
+
+            <!-- Right side -->
+            <Grid Grid.Column="2">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition />
+                    <RowDefinition />
+                    <RowDefinition />
+                    <RowDefinition />
+                    <RowDefinition Height="*" />
+                </Grid.RowDefinitions>
+
+                <TextBlock Grid.Row="0" Grid.ColumnSpan="3" Style="{StaticResource MaterialDesignSubtitle1TextBlock}">
+                    Color calibration
+                </TextBlock>
+
+                <TextBlock Grid.Row="1" 
+                           Grid.Column="0"
+                           Grid.ColumnSpan="3"
+                           Style="{StaticResource MaterialDesignCaptionTextBlock}" 
+                           Foreground="{DynamicResource MaterialDesignBodyLight}"
+                           TextWrapping="Wrap" 
+                           TextAlignment="Justify">
+                    Use the sliders below to adjust the colors of your device so that it matches your other devices.
+                </TextBlock>
+
+                <Label Grid.Row="2" Grid.Column="0" Content="R-" VerticalAlignment="Center" />
+                <Slider Grid.Row="2"
+                        Grid.Column="1"
+                        Minimum="0"
+                        Maximum="200"
+                        ValueChanged="{s:Action ApplyScaling}"
+                        Value="{Binding RedScale, UpdateSourceTrigger=PropertyChanged}"
+                        Margin="10 0"
+                        VerticalAlignment="Center" />
+                <Label Grid.Row="2" Grid.Column="2" Content="R+" VerticalAlignment="Center" />
+
+                <Label Grid.Row="3" Grid.Column="0" Content="G-" VerticalAlignment="Center" />
+                <Slider Grid.Row="3"
+                        Grid.Column="1"
+                        Minimum="0"
+                        Maximum="200"
+                        ValueChanged="{s:Action ApplyScaling}"
+                        Value="{Binding GreenScale, UpdateSourceTrigger=PropertyChanged}"
+                        Margin="10 0"
+                        VerticalAlignment="Center" />
+                <Label Grid.Row="3" Grid.Column="2" Content="G+" VerticalAlignment="Center" />
+
+                <Label Grid.Row="4" Grid.Column="0" Content="B-" VerticalAlignment="Center" />
+                <Slider Grid.Row="4"
+                        Grid.Column="1"
+                        Minimum="0"
+                        Maximum="200"
+                        ValueChanged="{s:Action ApplyScaling}"
+                        Value="{Binding BlueScale, UpdateSourceTrigger=PropertyChanged}"
+                        Margin="10 0"
+                        VerticalAlignment="Center" />
+                <Label Grid.Row="4" Grid.Column="2" Content="B+" VerticalAlignment="Center" />
+
+                <Grid Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="3">
                     <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="Auto"
-                                          MinWidth="41" />
-                        <ColumnDefinition Width="Auto"
-                                          MinWidth="184.937" />
+                        <ColumnDefinition />
+                        <ColumnDefinition />
                     </Grid.ColumnDefinitions>
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="Auto" />
-                        <RowDefinition Height="Auto" />
-                        <RowDefinition Height="Auto" />
-                    </Grid.RowDefinitions>
-
-                    <Label Grid.Column="0"
-                           Grid.Row="0"
-                           Content="Red"
-                           VerticalAlignment="Bottom" />
-                    <Slider Grid.Column="1"
-                            Grid.Row="0"
-                            Minimum="0"
-                            Maximum="200"
-                            ValueChanged="{s:Action ApplyScaling}"
-                            Value="{Binding RedScale, UpdateSourceTrigger=PropertyChanged}"
-                            Style="{StaticResource MaterialDesignDiscreteSlider}" />
-
-                    <Label Grid.Column="0"
-                           Grid.Row="1"
-                           Content="Green"
-                           VerticalAlignment="Bottom" />
-                    <Slider Grid.Column="1"
-                            Grid.Row="1"
-                            Minimum="0"
-                            Maximum="200"
-                            ValueChanged="{s:Action ApplyScaling}"
-                            Value="{Binding GreenScale, UpdateSourceTrigger=PropertyChanged}"
-                            Style="{StaticResource MaterialDesignDiscreteSlider}" />
-
-                    <Label Grid.Column="0"
-                           Grid.Row="2"
-                           Content="Blue"
-                           VerticalAlignment="Bottom" />
-                    <Slider Grid.Column="1"
-                            Grid.Row="2"
-                            Minimum="0"
-                            Maximum="200"
-                            ValueChanged="{s:Action ApplyScaling}"
-                            Value="{Binding BlueScale, UpdateSourceTrigger=PropertyChanged}"
-                            Style="{StaticResource MaterialDesignDiscreteSlider}" />
-                </Grid>
-                <DockPanel>
-                    <CheckBox IsChecked="{Binding DisplayOnDevices}"
-                              Margin="5,0,0,0"
-                              Content="Display on Devices"
-                              HorizontalAlignment="Left" />
-                    <shared:ColorPicker Margin="0,0,5,0"
+                    <CheckBox Grid.Column="0"
+                              IsChecked="{Binding DisplayOnDevices}"
+                              Content="Show preview"
+                              VerticalAlignment="Center" />
+                    <shared:ColorPicker Grid.Column="1"
+                                        Margin="0,0,5,0"
                                         HorizontalAlignment="Right"
-                                        Color="{Binding CurrentColor, Converter={StaticResource SKColorToColorConverter}}" />
-                </DockPanel>
+                                        Color="{Binding CurrentColor, Converter={StaticResource SKColorToColorConverter}}" 
+                                        VerticalAlignment="Center"/>
+                </Grid>
+            </Grid>
+        </Grid>
 
-            </StackPanel>
-        </StackPanel>
-
+        <!-- Buttons -->
         <StackPanel Orientation="Horizontal"
                     HorizontalAlignment="Right">
             <Button Style="{StaticResource MaterialDesignFlatButton}"
@@ -133,6 +162,5 @@
                 APPLY
             </Button>
         </StackPanel>
-
     </StackPanel>
 </UserControl>

--- a/src/Artemis.UI/Screens/SurfaceEditor/Dialogs/SurfaceDeviceConfigView.xaml
+++ b/src/Artemis.UI/Screens/SurfaceEditor/Dialogs/SurfaceDeviceConfigView.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl x:Class="Artemis.UI.Screens.SurfaceEditor.Dialogs.SurfaceDeviceConfigView"
+<UserControl x:Class="Artemis.UI.Screens.SurfaceEditor.Dialogs.SurfaceDeviceConfigView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -15,7 +15,7 @@
     <StackPanel Margin="16" Width="400">
         <!-- Title -->
         <TextBlock Text="{Binding Device.RgbDevice.DeviceInfo.DeviceName}" Style="{StaticResource MaterialDesignHeadline6TextBlock}" />
-        
+
         <!-- Body -->
         <Grid Margin="0 25 0 0">
             <Grid.ColumnDefinitions>
@@ -75,17 +75,20 @@
                     Color calibration
                 </TextBlock>
 
-                <TextBlock Grid.Row="1" 
+                <TextBlock Grid.Row="1"
                            Grid.Column="0"
                            Grid.ColumnSpan="3"
-                           Style="{StaticResource MaterialDesignCaptionTextBlock}" 
+                           Style="{StaticResource MaterialDesignCaptionTextBlock}"
                            Foreground="{DynamicResource MaterialDesignBodyLight}"
-                           TextWrapping="Wrap" 
+                           TextWrapping="Wrap"
                            TextAlignment="Justify">
                     Use the sliders below to adjust the colors of your device so that it matches your other devices.
                 </TextBlock>
 
-                <Label Grid.Row="2" Grid.Column="0" Content="R-" VerticalAlignment="Center" />
+                <Label Grid.Row="2"
+                       Grid.Column="0"
+                       Content="R"
+                       VerticalAlignment="Center" />
                 <Slider Grid.Row="2"
                         Grid.Column="1"
                         Minimum="0"
@@ -94,9 +97,17 @@
                         Value="{Binding RedScale, UpdateSourceTrigger=PropertyChanged}"
                         Margin="10 0"
                         VerticalAlignment="Center" />
-                <Label Grid.Row="2" Grid.Column="2" Content="R+" VerticalAlignment="Center" />
+                <TextBox Grid.Row="2"
+                         Grid.Column="2"
+                         VerticalAlignment="Center"
+                         Text="{Binding RedScale, StringFormat={}{0:0.0}, UpdateSourceTrigger=PropertyChanged}"
+                         materialDesign:TextFieldAssist.SuffixText="%"
+                         Width="50" />
 
-                <Label Grid.Row="3" Grid.Column="0" Content="G-" VerticalAlignment="Center" />
+                <Label Grid.Row="3"
+                       Grid.Column="0"
+                       Content="G"
+                       VerticalAlignment="Center" />
                 <Slider Grid.Row="3"
                         Grid.Column="1"
                         Minimum="0"
@@ -105,9 +116,17 @@
                         Value="{Binding GreenScale, UpdateSourceTrigger=PropertyChanged}"
                         Margin="10 0"
                         VerticalAlignment="Center" />
-                <Label Grid.Row="3" Grid.Column="2" Content="G+" VerticalAlignment="Center" />
+                <TextBox Grid.Row="3"
+                         Grid.Column="2"
+                         VerticalAlignment="Center"
+                         Text="{Binding GreenScale, StringFormat={}{0:0.0}, UpdateSourceTrigger=PropertyChanged}"
+                         materialDesign:TextFieldAssist.SuffixText="%"
+                         Width="50" />
 
-                <Label Grid.Row="4" Grid.Column="0" Content="B-" VerticalAlignment="Center" />
+                <Label Grid.Row="4"
+                       Grid.Column="0"
+                       Content="B"
+                       VerticalAlignment="Center" />
                 <Slider Grid.Row="4"
                         Grid.Column="1"
                         Minimum="0"
@@ -115,8 +134,14 @@
                         ValueChanged="{s:Action ApplyScaling}"
                         Value="{Binding BlueScale, UpdateSourceTrigger=PropertyChanged}"
                         Margin="10 0"
+                        Ticks="100"
                         VerticalAlignment="Center" />
-                <Label Grid.Row="4" Grid.Column="2" Content="B+" VerticalAlignment="Center" />
+                <TextBox Grid.Row="4"
+                         Grid.Column="2"
+                         VerticalAlignment="Center"
+                         Text="{Binding BlueScale, StringFormat={}{0:0.0}, UpdateSourceTrigger=PropertyChanged}"
+                         materialDesign:TextFieldAssist.SuffixText="%"
+                         Width="50" />
 
                 <Grid Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="3">
                     <Grid.ColumnDefinitions>

--- a/src/Artemis.UI/Screens/SurfaceEditor/Dialogs/SurfaceDeviceConfigView.xaml
+++ b/src/Artemis.UI/Screens/SurfaceEditor/Dialogs/SurfaceDeviceConfigView.xaml
@@ -4,37 +4,115 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:s="https://github.com/canton7/Stylet"
+             xmlns:shared="clr-namespace:Artemis.UI.Shared;assembly=Artemis.UI.Shared"
              xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
              xmlns:surfaceEditor="clr-namespace:Artemis.UI.Screens.SurfaceEditor.Dialogs"
              mc:Ignorable="d"
-             d:DesignHeight="351.305" d:DesignWidth="262.163"
              d:DataContext="{d:DesignInstance {x:Type surfaceEditor:SurfaceDeviceConfigViewModel}}">
+    <UserControl.Resources>
+        <shared:SKColorToColorConverter x:Key="SKColorToColorConverter" />
+    </UserControl.Resources>
     <StackPanel Margin="16">
-        <TextBlock Text="{Binding Title}" Style="{StaticResource MaterialDesignHeadline6TextBlock}" />
-        <TextBlock Text="Note: These are not being validated yet" Style="{StaticResource MaterialDesignSubtitle1TextBlock}" />
+        <TextBlock Text="{Binding Title}"
+                   Style="{StaticResource MaterialDesignHeadline6TextBlock}" />
+        <TextBlock Text="Note: These are not being validated yet"
+                   Style="{StaticResource MaterialDesignSubtitle1TextBlock}" />
 
-        <TextBox materialDesign:HintAssist.Hint="X-coordinate"
-                 materialDesign:TextFieldAssist.SuffixText="mm"
-                 Text="{Binding X, UpdateSourceTrigger=PropertyChanged}"
-                 Style="{StaticResource MaterialDesignFloatingHintTextBox}"
-                 Margin="0 10" />
-        <TextBox materialDesign:HintAssist.Hint="Y-coordinate"
-                 materialDesign:TextFieldAssist.SuffixText="mm"
-                 Text="{Binding Y, UpdateSourceTrigger=PropertyChanged}"
-                 Style="{StaticResource MaterialDesignFloatingHintTextBox}"
-                 Margin="0 10" />
-        <TextBox materialDesign:HintAssist.Hint="Scale"
-                 materialDesign:TextFieldAssist.SuffixText="times"
-                 Text="{Binding Scale, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource MaterialDesignFloatingHintTextBox}"
-                 Margin="0 10" />
-        <TextBox materialDesign:HintAssist.Hint="Rotation"
-                 materialDesign:TextFieldAssist.SuffixText="deg"
-                 Text="{Binding Rotation, UpdateSourceTrigger=PropertyChanged}"
-                 Style="{StaticResource MaterialDesignFloatingHintTextBox}"
-                 Margin="0 10" />
+        <StackPanel Orientation="Horizontal">
+            <StackPanel Orientation="Vertical"
+                        Width="150"
+                        Margin="8">
+                <TextBox materialDesign:HintAssist.Hint="X-coordinate"
+                         materialDesign:TextFieldAssist.SuffixText="mm"
+                         Text="{Binding X, UpdateSourceTrigger=PropertyChanged}"
+                         Style="{StaticResource MaterialDesignFloatingHintTextBox}"
+                         Margin="0 10" />
+                <TextBox materialDesign:HintAssist.Hint="Y-coordinate"
+                         materialDesign:TextFieldAssist.SuffixText="mm"
+                         Text="{Binding Y, UpdateSourceTrigger=PropertyChanged}"
+                         Style="{StaticResource MaterialDesignFloatingHintTextBox}"
+                         Margin="0 10" />
+                <TextBox materialDesign:HintAssist.Hint="Scale"
+                         materialDesign:TextFieldAssist.SuffixText="times"
+                         Text="{Binding Scale, UpdateSourceTrigger=PropertyChanged}"
+                         Style="{StaticResource MaterialDesignFloatingHintTextBox}"
+                         Margin="0 10" />
+                <TextBox materialDesign:HintAssist.Hint="Rotation"
+                         materialDesign:TextFieldAssist.SuffixText="deg"
+                         Text="{Binding Rotation, UpdateSourceTrigger=PropertyChanged}"
+                         Style="{StaticResource MaterialDesignFloatingHintTextBox}"
+                         Margin="0 10" />
+            </StackPanel>
+            <StackPanel Orientation="Vertical"
+                        Width="250"
+                        Margin="8">
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto"
+                                          MinWidth="41" />
+                        <ColumnDefinition Width="Auto"
+                                          MinWidth="184.937" />
+                    </Grid.ColumnDefinitions>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
 
-        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
-            <Button Style="{StaticResource MaterialDesignFlatButton}" IsCancel="True" Margin="0 8 8 0"
+                    <Label Grid.Column="0"
+                           Grid.Row="0"
+                           Content="Red"
+                           VerticalAlignment="Bottom" />
+                    <Slider Grid.Column="1"
+                            Grid.Row="0"
+                            Minimum="0"
+                            Maximum="200"
+                            ValueChanged="{s:Action ApplyScaling}"
+                            Value="{Binding RedScale, UpdateSourceTrigger=PropertyChanged}"
+                            Style="{StaticResource MaterialDesignDiscreteSlider}" />
+
+                    <Label Grid.Column="0"
+                           Grid.Row="1"
+                           Content="Green"
+                           VerticalAlignment="Bottom" />
+                    <Slider Grid.Column="1"
+                            Grid.Row="1"
+                            Minimum="0"
+                            Maximum="200"
+                            ValueChanged="{s:Action ApplyScaling}"
+                            Value="{Binding GreenScale, UpdateSourceTrigger=PropertyChanged}"
+                            Style="{StaticResource MaterialDesignDiscreteSlider}" />
+
+                    <Label Grid.Column="0"
+                           Grid.Row="2"
+                           Content="Blue"
+                           VerticalAlignment="Bottom" />
+                    <Slider Grid.Column="1"
+                            Grid.Row="2"
+                            Minimum="0"
+                            Maximum="200"
+                            ValueChanged="{s:Action ApplyScaling}"
+                            Value="{Binding BlueScale, UpdateSourceTrigger=PropertyChanged}"
+                            Style="{StaticResource MaterialDesignDiscreteSlider}" />
+                </Grid>
+                <DockPanel>
+                    <CheckBox IsChecked="{Binding DisplayOnDevices}"
+                              Margin="5,0,0,0"
+                              Content="Display on Devices"
+                              HorizontalAlignment="Left" />
+                    <shared:ColorPicker Margin="0,0,5,0"
+                                        HorizontalAlignment="Right"
+                                        Color="{Binding CurrentColor, Converter={StaticResource SKColorToColorConverter}}" />
+                </DockPanel>
+
+            </StackPanel>
+        </StackPanel>
+
+        <StackPanel Orientation="Horizontal"
+                    HorizontalAlignment="Right">
+            <Button Style="{StaticResource MaterialDesignFlatButton}"
+                    IsCancel="True"
+                    Margin="0 8 8 0"
                     Command="{s:Action Cancel}">
                 <Button.CommandParameter>
                     <system:Boolean xmlns:system="clr-namespace:System;assembly=mscorlib">
@@ -43,7 +121,9 @@
                 </Button.CommandParameter>
                 CANCEL
             </Button>
-            <Button Style="{StaticResource MaterialDesignFlatButton}" IsDefault="True" Margin="0 8 8 0"
+            <Button Style="{StaticResource MaterialDesignFlatButton}"
+                    IsDefault="True"
+                    Margin="0 8 8 0"
                     Command="{s:Action Accept}">
                 <Button.CommandParameter>
                     <system:Boolean xmlns:system="clr-namespace:System;assembly=mscorlib">
@@ -53,5 +133,6 @@
                 APPLY
             </Button>
         </StackPanel>
+
     </StackPanel>
 </UserControl>

--- a/src/Artemis.UI/Screens/SurfaceEditor/Dialogs/SurfaceDeviceConfigViewModel.cs
+++ b/src/Artemis.UI/Screens/SurfaceEditor/Dialogs/SurfaceDeviceConfigViewModel.cs
@@ -12,7 +12,6 @@ namespace Artemis.UI.Screens.SurfaceEditor.Dialogs
         private readonly ICoreService _coreService;
         private int _rotation;
         private double _scale;
-        private string _title;
         private int _x;
         private int _y;
         public double _redScale;
@@ -26,7 +25,6 @@ namespace Artemis.UI.Screens.SurfaceEditor.Dialogs
             _coreService = coreService;
 
             Device = device;
-            Title = $"{Device.RgbDevice.DeviceInfo.DeviceName} - Properties";
 
             X = (int)Device.X;
             Y = (int)Device.Y;
@@ -52,13 +50,6 @@ namespace Artemis.UI.Screens.SurfaceEditor.Dialogs
         }
 
         public ArtemisDevice Device { get; }
-
-
-        public string Title
-        {
-            get => _title;
-            set => SetAndNotify(ref _title, value);
-        }
 
         public int X
         {

--- a/src/Artemis.UI/Screens/SurfaceEditor/Dialogs/SurfaceDeviceConfigViewModel.cs
+++ b/src/Artemis.UI/Screens/SurfaceEditor/Dialogs/SurfaceDeviceConfigViewModel.cs
@@ -10,13 +10,16 @@ namespace Artemis.UI.Screens.SurfaceEditor.Dialogs
     public class SurfaceDeviceConfigViewModel : DialogViewModelBase
     {
         private readonly ICoreService _coreService;
+        private readonly double _initialRedScale;
+        private readonly double _initialGreenScale;
+        private readonly double _initialBlueScale;
         private int _rotation;
         private double _scale;
         private int _x;
         private int _y;
-        public double _redScale;
-        public double _greenScale;
-        public double _blueScale;
+        private double _redScale;
+        private double _greenScale;
+        private double _blueScale;
         private SKColor _currentColor;
         private bool _displayOnDevices;
 
@@ -33,6 +36,10 @@ namespace Artemis.UI.Screens.SurfaceEditor.Dialogs
             RedScale = Device.RedScale * 100d;
             GreenScale = Device.GreenScale * 100d;
             BlueScale = Device.BlueScale * 100d;
+            //we need to store the initial values to be able to restore them when the user clicks "Cancel"
+            _initialRedScale =  Device.RedScale;
+            _initialGreenScale = Device.GreenScale;
+            _initialBlueScale = Device.BlueScale;
             CurrentColor = SKColors.White;
             _coreService.FrameRendering += OnFrameRendering;
         }
@@ -129,11 +136,18 @@ namespace Artemis.UI.Screens.SurfaceEditor.Dialogs
 
         public void ApplyScaling()
         {
-            //TODO: we should either save or revert changes when the user clicks save or cancel.
-            //we might have to revert these changes below.
             Device.RedScale = RedScale / 100d;
             Device.GreenScale = GreenScale / 100d;
             Device.BlueScale = BlueScale / 100d;
+        }
+
+        public override void Cancel()
+        {
+            Device.RedScale = _initialRedScale;
+            Device.GreenScale = _initialGreenScale;
+            Device.BlueScale = _initialBlueScale;
+
+            base.Cancel();
         }
     }
 }


### PR DESCRIPTION
Closes #512 

Adds a UI to test and apply color calibration to the surface editor "View Properties" menu:
![image](https://user-images.githubusercontent.com/29486064/101987828-57bda100-3c8e-11eb-8f78-218c8ead5a5f.png)

Allows the user to apply a color to all devices when the checkbox is ticked, allowing for comparison with other rgb devices.