### PR TITLE
Fix null object exception on Gradient Editor DEL Hotkey

### DIFF
--- a/src/Artemis.UI.Shared/Screens/GradientEditor/GradientEditorViewModel.cs
+++ b/src/Artemis.UI.Shared/Screens/GradientEditor/GradientEditorViewModel.cs
@@ -65,6 +65,9 @@ namespace Artemis.UI.Shared.Screens.GradientEditor
 
         public void RemoveColorStop(ColorStopViewModel colorStopViewModel)
         {
+            if (colorStopViewModel == null)
+                return;
+
             ColorStopViewModels.Remove(colorStopViewModel);
             ColorGradient.Stops.Remove(colorStopViewModel.ColorStop);
             ColorGradient.OnColorValuesUpdated();


### PR DESCRIPTION
Fix a null object exception that occurs if DEL key is pressed in the gradient editor without selecting a color step.

Object reference not set to an instance of an object.

   at void Artemis.UI.Shared.Screens.GradientEditor.GradientEditorViewModel.RemoveColorStop(ColorStopViewModel colorStopViewModel) in D:/Repos/Artemis/src/Artemis.UI.Shared/Screens/GradientEditor/GradientEditorViewModel.cs:line 69
   at void Stylet.Xaml.ActionBase.InvokeTargetMethod(object[] parameters)
   at void Stylet.Xaml.CommandAction.Execute(object parameter)
   at void System.Windows.Input.CommandManager.TranslateInput(IInputElement targetElement, InputEventArgs inputEventArgs)
   at void System.Windows.UIElement.OnKeyDownThunk(object sender, KeyEventArgs e)
   at void System.Windows.RoutedEventArgs.InvokeHandler(Delegate handler, object target)
   at void System.Windows.EventRoute.InvokeHandlersImpl(object source, RoutedEventArgs args, bool reRaised)
   at void System.Windows.UIElement.RaiseEventImpl(DependencyObject sender, RoutedEventArgs args)
   at void System.Windows.UIElement.RaiseTrustedEvent(RoutedEventArgs args)
   at bool System.Windows.Input.InputManager.ProcessStagingArea()
   at bool System.Windows.Input.InputProviderSite.ReportInput(InputReport inputReport)
   at void System.Windows.Interop.HwndKeyboardInputProvider.ProcessKeyAction(ref MSG msg, ref bool handled)
   at bool System.Windows.Interop.HwndSource.CriticalTranslateAccelerator(ref MSG msg, ModifierKeys modifiers)
   at object System.Windows.Interop.HwndSource.OnPreprocessMessage(object param)
   at object System.Windows.Threading.ExceptionWrapper.InternalRealCall(Delegate callback, object args, int numArgs)
   at object System.Windows.Threading.ExceptionWrapper.TryCatchWhen(object source, Delegate callback, object args, int numArgs, Delegate catchHandler)