### PR TITLE
Add Gradient Tools

### DIFF
--- a/src/Artemis.UI.Shared/Controls/ColorPicker.xaml
+++ b/src/Artemis.UI.Shared/Controls/ColorPicker.xaml
@@ -73,7 +73,9 @@
                  MinWidth="95"
                  MaxLength="9"
                  Margin="0"
-                 HorizontalAlignment="Stretch">
+                 HorizontalAlignment="Stretch"
+                 FontFamily="Consolas"
+                 CharacterCasing="Upper">
             <materialDesign:TextFieldAssist.CharacterCounterStyle>
                 <Style TargetType="TextBlock" />
             </materialDesign:TextFieldAssist.CharacterCounterStyle>
@@ -82,7 +84,7 @@
         <Border Width="15"
                 Height="15"
                 CornerRadius="15"
-                Margin="0 0 8 0"
+                Margin="0 0 2 0"
                 VerticalAlignment="Center"
                 HorizontalAlignment="Right"
                 Background="{StaticResource Checkerboard}">

--- a/src/Artemis.UI.Shared/Screens/GradientEditor/ColorStopViewModel.cs
+++ b/src/Artemis.UI.Shared/Screens/GradientEditor/ColorStopViewModel.cs
@@ -32,6 +32,7 @@ namespace Artemis.UI.Shared.Screens.GradientEditor
                 ColorStop.Position = (float) Math.Round(value / _gradientEditorViewModel.PreviewWidth, 3, MidpointRounding.AwayFromZero);
                 NotifyOfPropertyChange(nameof(Offset));
                 NotifyOfPropertyChange(nameof(OffsetPercent));
+                NotifyOfPropertyChange(nameof(OffsetFloat));
             }
         }
 
@@ -43,6 +44,20 @@ namespace Artemis.UI.Shared.Screens.GradientEditor
                 ColorStop.Position = Math.Min(100, Math.Max(0, value)) / 100f;
                 NotifyOfPropertyChange(nameof(Offset));
                 NotifyOfPropertyChange(nameof(OffsetPercent));
+                NotifyOfPropertyChange(nameof(OffsetFloat));
+            }
+        }
+
+        // Functionally similar to Offset Percent, but doesn't round on get in order to prevent inconsistencies (and is 0 to 1)
+        public float OffsetFloat
+        {
+            get => ColorStop.Position;
+            set
+            {
+                ColorStop.Position = Math.Min(1, Math.Max(0, value));
+                NotifyOfPropertyChange(nameof(Offset));
+                NotifyOfPropertyChange(nameof(OffsetPercent));
+                NotifyOfPropertyChange(nameof(OffsetFloat));
             }
         }
 

--- a/src/Artemis.UI.Shared/Screens/GradientEditor/GradientEditorView.xaml
+++ b/src/Artemis.UI.Shared/Screens/GradientEditor/GradientEditorView.xaml
@@ -40,7 +40,7 @@
         </VisualBrush>
     </UserControl.Resources>
     <UserControl.InputBindings>
-        <KeyBinding Key="Delete" Command="{s:Action RemoveColorStop}" CommandParameter="{Binding SelectedColorStopViewModel}"/>
+        <KeyBinding Key="Delete" Command="{s:Action RemoveColorStop}" CommandParameter="{Binding SelectedColorStopViewModel}" />
     </UserControl.InputBindings>
     <Grid Margin="16">
         <Grid.RowDefinitions>
@@ -60,55 +60,59 @@
         </StackPanel>
         <Separator Grid.Row="1" Margin="0 5" />
         <StackPanel Grid.Row="2" Margin="0 5" ClipToBounds="False">
-            <Grid>
-                <TextBlock Margin="0 5">Gradient</TextBlock>
-                <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
-                    <Button Style="{StaticResource MaterialDesignFlatButton}" 
-                        Margin="0 0 5 4"
-                        Padding="0"
-                        Command="{s:Action SpreadColorStops}" 
-                        ToolTip="Spread Stops" IsEnabled="{Binding HasMoreThanOneStop}" 
-                        HorizontalAlignment="Left"
-                        Height="25" Width="25">
-                        <materialDesign:PackIcon Kind="ArrowLeftRight"/>
+            <Grid Margin="0 0 0 5">
+                <TextBlock Margin="0 5" VerticalAlignment="Center">Gradient</TextBlock>
+                <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Center">
+                    <Button Style="{StaticResource MaterialDesignFlatButton}"
+                            Margin="0 0 5 0"
+                            Padding="0"
+                            Command="{s:Action SpreadColorStops}"
+                            ToolTip="Spread Stops"
+                            IsEnabled="{Binding HasMoreThanOneStop}"
+                            HorizontalAlignment="Left"
+                            Height="25" Width="25">
+                        <materialDesign:PackIcon Kind="ArrowLeftRight" />
                     </Button>
-                    <Button Style="{StaticResource MaterialDesignFlatButton}" 
-                        Margin="0 0 5 4"
-                        Padding="0"
-                        Command="{s:Action ToggleSeam}" 
-                        ToolTip="Toggle Seamless" IsEnabled="{Binding HasMoreThanOneStop}" 
-                        HorizontalAlignment="Left"
-                        Height="25" Width="25">
-                        <materialDesign:PackIcon Kind="SineWave"/>
+                    <Button Style="{StaticResource MaterialDesignFlatButton}"
+                            Margin="0 0 5 0"
+                            Padding="0"
+                            Command="{s:Action ToggleSeam}"
+                            ToolTip="Toggle Seamless"
+                            IsEnabled="{Binding HasMoreThanOneStop}"
+                            HorizontalAlignment="Left"
+                            Height="25" Width="25">
+                        <materialDesign:PackIcon Kind="SineWave" />
                     </Button>
-                    <Button Style="{StaticResource MaterialDesignFlatButton}" 
-                        Margin="0 0 5 4"
-                        Padding="0"
-                        Command="{s:Action FlipColorStops}" 
-                        ToolTip="Flip Stops" IsEnabled="{Binding HasMoreThanOneStop}" 
-                        HorizontalAlignment="Left"
-                        Height="25" Width="25">
-                        <materialDesign:PackIcon Kind="FlipHorizontal"/>
+                    <Button Style="{StaticResource MaterialDesignFlatButton}"
+                            Margin="0 0 5 0"
+                            Padding="0"
+                            Command="{s:Action FlipColorStops}"
+                            ToolTip="Flip Stops"
+                            IsEnabled="{Binding HasMoreThanOneStop}"
+                            HorizontalAlignment="Left"
+                            Height="25" Width="25">
+                        <materialDesign:PackIcon Kind="FlipHorizontal" />
                     </Button>
-                    <Button Style="{StaticResource MaterialDesignFlatButton}" 
-                        Margin="0 0 5 4"
-                        Padding="0"
-                        Command="{s:Action RotateColorStops}" 
-                        ToolTip="Rotate Stops (shift to invert)" IsEnabled="{Binding HasMoreThanOneStop}" 
-                        HorizontalAlignment="Left"
-                        Height="25" Width="25">
-                        <materialDesign:PackIcon Kind="AxisZRotateCounterclockwise"/>
+                    <Button Style="{StaticResource MaterialDesignFlatButton}"
+                            Margin="0 0 5 0"
+                            Padding="0"
+                            Command="{s:Action RotateColorStops}"
+                            ToolTip="Rotate Stops (shift to invert)"
+                            IsEnabled="{Binding HasMoreThanOneStop}"
+                            HorizontalAlignment="Left"
+                            Height="25" Width="25">
+                        <materialDesign:PackIcon Kind="AxisZRotateCounterclockwise" />
                     </Button>
-                    <Button Style="{StaticResource MaterialDesignFlatButton}" 
-                        Margin="0 0 5 4"
-                        Padding="0"
-                        Command="{s:Action ShowClearGradientPopup}" 
-                        ToolTip="Clear All Color Stops" IsEnabled="{Binding HasMoreThanOneStop}" 
-                        HorizontalAlignment="Left"
-                        Height="25" Width="25"
-                        x:Name="ClearGradientButton">
+                    <Button Style="{StaticResource MaterialDesignFlatButton}"
+                            Padding="0"
+                            Command="{s:Action ShowClearGradientPopup}"
+                            ToolTip="Clear All Color Stops"
+                            IsEnabled="{Binding HasMoreThanOneStop}"
+                            HorizontalAlignment="Left"
+                            Height="25" Width="25"
+                            x:Name="ClearGradientButton">
                         <StackPanel>
-                            <materialDesign:PackIcon Kind="DeleteSweep"/>
+                            <materialDesign:PackIcon Kind="DeleteSweep" />
                         </StackPanel>
                     </Button>
                     <Popup
@@ -121,7 +125,7 @@
                         StaysOpen="False"
                         PopupAnimation="Fade"
                         IsOpen="{Binding ClearGradientPopupOpen, Mode=OneWay}">
-                        <materialDesign:Card Margin="30" Padding="12" materialDesign:ShadowAssist.ShadowDepth="Depth4" >
+                        <materialDesign:Card Margin="30" Padding="12" materialDesign:ShadowAssist.ShadowDepth="Depth4">
                             <StackPanel HorizontalAlignment="Center">
                                 <TextBlock Style="{StaticResource MaterialDesignSubtitle2TextBlock}" TextAlignment="Center" Margin="0 0 0 10">Clear Gradient?</TextBlock>
                                 <StackPanel Orientation="Horizontal">
@@ -195,10 +199,10 @@
                         CommandParameter="{Binding SelectedColorStopViewModel}"
                         ToolTip="Delete Selected Stop">
                     <Button.Resources>
-                        <SolidColorBrush x:Key="PrimaryHueMidBrush" Color="#c94848"/>
+                        <SolidColorBrush x:Key="PrimaryHueMidBrush" Color="#c94848" />
                     </Button.Resources>
                     <StackPanel Orientation="Horizontal">
-                        <materialDesign:PackIcon Kind="Delete"/>
+                        <materialDesign:PackIcon Kind="Delete" />
                         <TextBlock Margin="4 0 0 0">Delete</TextBlock>
                     </StackPanel>
                 </Button>

--- a/src/Artemis.UI.Shared/Screens/GradientEditor/GradientEditorView.xaml
+++ b/src/Artemis.UI.Shared/Screens/GradientEditor/GradientEditorView.xaml
@@ -12,8 +12,8 @@
              Background="{DynamicResource MaterialDesignPaper}"
              FontFamily="pack://application:,,,/MaterialDesignThemes.Wpf;component/Resources/Roboto/#Roboto"
              Width="400"
-             Height="425"
-             d:DesignHeight="425"
+             Height="450"
+             d:DesignHeight="450"
              d:DesignWidth="400"
              d:DataContext="{d:DesignInstance local:GradientEditorViewModel}">
     <UserControl.Resources>
@@ -90,38 +90,63 @@
                     </DataTemplate>
                 </ItemsControl.ItemTemplate>
             </ItemsControl>
-            <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+            <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="0">
                 <Button Style="{StaticResource MaterialDesignOutlinedButton}" 
-                    Margin="0 8 8 8"
+                    Margin="0 4 8 8"
                     Command="{s:Action SpreadColorStops}" 
-                    ToolTip="Distribute Stops" IsEnabled="{Binding HasMoreThanOneStop}" 
+                    ToolTip="Spread Stops" IsEnabled="{Binding HasMoreThanOneStop}" 
                     HorizontalAlignment="Left"
-                    Height="25">
+                    Height="25" Width="100">
                     <StackPanel Orientation="Horizontal">
                         <materialDesign:PackIcon Kind="DistributeHorizontalCenter"/>
-                        <TextBlock Margin="6 0 0 0">Distribute</TextBlock>
+                        <TextBlock Margin="6 0 0 0">Spread</TextBlock>
                     </StackPanel>
                 </Button>
                 <Button Style="{StaticResource MaterialDesignOutlinedButton}" 
-                    Margin="0 8 8 8"
+                    Margin="0 4 8 8"
                     Command="{s:Action RotateColorStops}" 
                     ToolTip="Rotate Stops" IsEnabled="{Binding HasMoreThanOneStop}" 
                     HorizontalAlignment="Left"
-                    Height="25">
+                    Height="25" Width="100">
                     <StackPanel Orientation="Horizontal">
                         <materialDesign:PackIcon Kind="AxisZRotateCounterclockwise" />
                         <TextBlock Margin="6 0 0 0">Rotate</TextBlock>
                     </StackPanel>
                 </Button>
                 <Button Style="{StaticResource MaterialDesignOutlinedButton}" 
-                    Margin="0 8 8 8"
+                    Margin="0 0 8 0"
                     Command="{s:Action FlipColorStops}" 
                     IsEnabled="{Binding HasMoreThanOneStop}" 
                     HorizontalAlignment="Left"
-                    Height="25" ToolTip="Flip Stops">
+                    Height="25" Width="100" ToolTip="Flip Stops">
                     <StackPanel Orientation="Horizontal">
                         <materialDesign:PackIcon Kind="FlipHorizontal"/>
                         <TextBlock Margin="6 0 0 0">Flip</TextBlock>
+                    </StackPanel>
+                </Button>
+            </StackPanel>
+            <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="0">
+                
+                <Button Style="{StaticResource MaterialDesignOutlinedButton}" 
+                    Margin="0 0 8 0"
+                    Command="{s:Action ToggleSeam}" 
+                    IsEnabled="{Binding HasMoreThanOneStop}" 
+                    HorizontalAlignment="Left"
+                    Height="25" Width="100" ToolTip="Toggle Seam">
+                    <StackPanel Orientation="Horizontal">
+                        <materialDesign:PackIcon Kind="ArrowSplitVertical"/>
+                        <TextBlock Margin="6 0 0 0">Seam</TextBlock>
+                    </StackPanel>
+                </Button>
+                <Button Style="{StaticResource MaterialDesignOutlinedButton}" 
+                    Margin="0 0 8 0"
+                    Command="{s:Action ClearGradient}" 
+                    IsEnabled="{Binding HasMoreThanOneStop}" 
+                    HorizontalAlignment="Left"
+                    Height="25" Width="100" ToolTip="Clear Gradient">
+                    <StackPanel Orientation="Horizontal">
+                        <materialDesign:PackIcon Kind="DeleteSweep"/>
+                        <TextBlock Margin="6 0 0 0">Clear</TextBlock>
                     </StackPanel>
                 </Button>
             </StackPanel>
@@ -135,7 +160,7 @@
                 </Grid.ColumnDefinitions>
 
                 <StackPanel Grid.Column="0" Orientation="Horizontal">
-                    <Label HorizontalAlignment="Left" Margin="-5,0,0,0">Color:</Label>
+                    <Label HorizontalAlignment="Left" Margin="-5,1,0,0">Color:</Label>
                     <shared:ColorPicker
                         x:Name="CurrentColor"
                         Width="85"
@@ -144,7 +169,7 @@
                         IsEnabled="{Binding HasSelectedColorStopViewModel}" />
 
                     <Label HorizontalAlignment="Center">Location:</Label>
-                    <TextBox Width="40"
+                    <TextBox Width="30"
                              Text="{Binding SelectedColorStopViewModel.OffsetPercent}"
                              IsEnabled="{Binding HasSelectedColorStopViewModel}"
                              materialDesign:HintAssist.Hint="0"

--- a/src/Artemis.UI.Shared/Screens/GradientEditor/GradientEditorView.xaml
+++ b/src/Artemis.UI.Shared/Screens/GradientEditor/GradientEditorView.xaml
@@ -114,7 +114,7 @@
                     </StackPanel>
                 </Button>
                 <Button Style="{StaticResource MaterialDesignOutlinedButton}" 
-                    Margin="0 0 8 0"
+                    Margin="0 4 8 8"
                     Command="{s:Action FlipColorStops}" 
                     IsEnabled="{Binding HasMoreThanOneStop}" 
                     HorizontalAlignment="Left"

--- a/src/Artemis.UI.Shared/Screens/GradientEditor/GradientEditorView.xaml
+++ b/src/Artemis.UI.Shared/Screens/GradientEditor/GradientEditorView.xaml
@@ -12,9 +12,9 @@
              Background="{DynamicResource MaterialDesignPaper}"
              FontFamily="pack://application:,,,/MaterialDesignThemes.Wpf;component/Resources/Roboto/#Roboto"
              Width="400"
-             Height="400"
-             d:DesignHeight="450"
-             d:DesignWidth="800"
+             Height="425"
+             d:DesignHeight="425"
+             d:DesignWidth="400"
              d:DataContext="{d:DesignInstance local:GradientEditorViewModel}">
     <UserControl.Resources>
         <shared:ColorGradientToGradientStopsConverter x:Key="ColorGradientToGradientStopsConverter" />
@@ -90,8 +90,43 @@
                     </DataTemplate>
                 </ItemsControl.ItemTemplate>
             </ItemsControl>
-
-            <TextBlock Margin="0 5">Selected stop</TextBlock>
+            <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                <Button Style="{StaticResource MaterialDesignOutlinedButton}" 
+                    Margin="0 8 8 8"
+                    Command="{s:Action SpreadColorStops}" 
+                    ToolTip="Distribute Stops" IsEnabled="{Binding HasMoreThanOneStop}" 
+                    HorizontalAlignment="Left"
+                    Height="25">
+                    <StackPanel Orientation="Horizontal">
+                        <materialDesign:PackIcon Kind="DistributeHorizontalCenter"/>
+                        <TextBlock Margin="6 0 0 0">Distribute</TextBlock>
+                    </StackPanel>
+                </Button>
+                <Button Style="{StaticResource MaterialDesignOutlinedButton}" 
+                    Margin="0 8 8 8"
+                    Command="{s:Action RotateColorStops}" 
+                    ToolTip="Rotate Stops" IsEnabled="{Binding HasMoreThanOneStop}" 
+                    HorizontalAlignment="Left"
+                    Height="25">
+                    <StackPanel Orientation="Horizontal">
+                        <materialDesign:PackIcon Kind="AxisZRotateCounterclockwise" />
+                        <TextBlock Margin="6 0 0 0">Rotate</TextBlock>
+                    </StackPanel>
+                </Button>
+                <Button Style="{StaticResource MaterialDesignOutlinedButton}" 
+                    Margin="0 8 8 8"
+                    Command="{s:Action FlipColorStops}" 
+                    IsEnabled="{Binding HasMoreThanOneStop}" 
+                    HorizontalAlignment="Left"
+                    Height="25" ToolTip="Flip Stops">
+                    <StackPanel Orientation="Horizontal">
+                        <materialDesign:PackIcon Kind="FlipHorizontal"/>
+                        <TextBlock Margin="6 0 0 0">Flip</TextBlock>
+                    </StackPanel>
+                </Button>
+            </StackPanel>
+            
+            <TextBlock Margin="0 6 0 0" FontWeight="Bold">Selected stop:</TextBlock>
 
             <Grid Margin="0 5">
                 <Grid.ColumnDefinitions>
@@ -122,8 +157,12 @@
                         Margin="8,0,0,0"
                         IsEnabled="{Binding HasSelectedColorStopViewModel}"
                         Command="{s:Action RemoveColorStop}"
-                        CommandParameter="{Binding SelectedColorStopViewModel}">
-                    DELETE
+                        CommandParameter="{Binding SelectedColorStopViewModel}"
+                        ToolTip="Delete Selected Stop">
+                    <StackPanel Orientation="Horizontal">
+                        <materialDesign:PackIcon Kind="Delete"/>
+                        <TextBlock Margin="4 0 0 0">Delete</TextBlock>
+                    </StackPanel>
                 </Button>
             </Grid>
         </StackPanel>

--- a/src/Artemis.UI.Shared/Screens/GradientEditor/GradientEditorView.xaml
+++ b/src/Artemis.UI.Shared/Screens/GradientEditor/GradientEditorView.xaml
@@ -60,8 +60,79 @@
         </StackPanel>
         <Separator Grid.Row="1" Margin="0 5" />
         <StackPanel Grid.Row="2" Margin="0 5" ClipToBounds="False">
-            <TextBlock Margin="0 5">Gradient</TextBlock>
-
+            <Grid>
+                <TextBlock Margin="0 5">Gradient</TextBlock>
+                <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                    <Button Style="{StaticResource MaterialDesignFlatButton}" 
+                        Margin="0 0 5 4"
+                        Padding="0"
+                        Command="{s:Action SpreadColorStops}" 
+                        ToolTip="Spread Stops" IsEnabled="{Binding HasMoreThanOneStop}" 
+                        HorizontalAlignment="Left"
+                        Height="25" Width="25">
+                        <materialDesign:PackIcon Kind="ArrowLeftRight"/>
+                    </Button>
+                    <Button Style="{StaticResource MaterialDesignFlatButton}" 
+                        Margin="0 0 5 4"
+                        Padding="0"
+                        Command="{s:Action ToggleSeam}" 
+                        ToolTip="Toggle Seamless" IsEnabled="{Binding HasMoreThanOneStop}" 
+                        HorizontalAlignment="Left"
+                        Height="25" Width="25">
+                        <materialDesign:PackIcon Kind="SineWave"/>
+                    </Button>
+                    <Button Style="{StaticResource MaterialDesignFlatButton}" 
+                        Margin="0 0 5 4"
+                        Padding="0"
+                        Command="{s:Action FlipColorStops}" 
+                        ToolTip="Flip Stops" IsEnabled="{Binding HasMoreThanOneStop}" 
+                        HorizontalAlignment="Left"
+                        Height="25" Width="25">
+                        <materialDesign:PackIcon Kind="FlipHorizontal"/>
+                    </Button>
+                    <Button Style="{StaticResource MaterialDesignFlatButton}" 
+                        Margin="0 0 5 4"
+                        Padding="0"
+                        Command="{s:Action RotateColorStops}" 
+                        ToolTip="Rotate Stops (shift to invert)" IsEnabled="{Binding HasMoreThanOneStop}" 
+                        HorizontalAlignment="Left"
+                        Height="25" Width="25">
+                        <materialDesign:PackIcon Kind="AxisZRotateCounterclockwise"/>
+                    </Button>
+                    <Button Style="{StaticResource MaterialDesignFlatButton}" 
+                        Margin="0 0 5 4"
+                        Padding="0"
+                        Command="{s:Action ShowClearGradientPopup}" 
+                        ToolTip="Clear All Color Stops" IsEnabled="{Binding HasMoreThanOneStop}" 
+                        HorizontalAlignment="Left"
+                        Height="25" Width="25"
+                        x:Name="ClearGradientButton">
+                        <StackPanel>
+                            <materialDesign:PackIcon Kind="DeleteSweep"/>
+                        </StackPanel>
+                    </Button>
+                    <Popup
+                        AllowsTransparency="True"
+                        Placement="Right"
+                        VerticalOffset="-25"
+                        HorizontalOffset="-5"
+                        CustomPopupPlacementCallback="{x:Static materialDesign:CustomPopupPlacementCallbackHelper.LargePopupCallback}"
+                        PlacementTarget="{Binding ElementName=ClearGradientButton}"
+                        StaysOpen="False"
+                        PopupAnimation="Fade"
+                        IsOpen="{Binding ClearGradientPopupOpen, Mode=OneWay}">
+                        <materialDesign:Card Margin="30" Padding="12" materialDesign:ShadowAssist.ShadowDepth="Depth4" >
+                            <StackPanel HorizontalAlignment="Center">
+                                <TextBlock Style="{StaticResource MaterialDesignSubtitle2TextBlock}" TextAlignment="Center" Margin="0 0 0 10">Clear Gradient?</TextBlock>
+                                <StackPanel Orientation="Horizontal">
+                                    <Button Command="{s:Action HideClearGradientPopup}" Style="{StaticResource MaterialDesignOutlinedButton}" Margin="0 0 10 0">No</Button>
+                                    <Button Command="{s:Action ClearGradientAndHide}">Yes</Button>
+                                </StackPanel>
+                            </StackPanel>
+                        </materialDesign:Card>
+                    </Popup>
+                </StackPanel>
+            </Grid>
             <Border Background="{StaticResource Checkerboard}">
                 <Rectangle x:Name="Preview" Height="40" shared:SizeObserver.Observe="True" shared:SizeObserver.ObservedWidth="{Binding PreviewWidth, Mode=OneWayToSource}">
                     <Rectangle.Fill>
@@ -90,67 +161,6 @@
                     </DataTemplate>
                 </ItemsControl.ItemTemplate>
             </ItemsControl>
-            <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="0">
-                <Button Style="{StaticResource MaterialDesignOutlinedButton}" 
-                    Margin="0 4 8 8"
-                    Command="{s:Action SpreadColorStops}" 
-                    ToolTip="Spread Stops" IsEnabled="{Binding HasMoreThanOneStop}" 
-                    HorizontalAlignment="Left"
-                    Height="25" Width="100">
-                    <StackPanel Orientation="Horizontal">
-                        <materialDesign:PackIcon Kind="DistributeHorizontalCenter"/>
-                        <TextBlock Margin="6 0 0 0">Spread</TextBlock>
-                    </StackPanel>
-                </Button>
-                <Button Style="{StaticResource MaterialDesignOutlinedButton}" 
-                    Margin="0 4 8 8"
-                    Command="{s:Action RotateColorStops}" 
-                    ToolTip="Rotate Stops" IsEnabled="{Binding HasMoreThanOneStop}" 
-                    HorizontalAlignment="Left"
-                    Height="25" Width="100">
-                    <StackPanel Orientation="Horizontal">
-                        <materialDesign:PackIcon Kind="AxisZRotateCounterclockwise" />
-                        <TextBlock Margin="6 0 0 0">Rotate</TextBlock>
-                    </StackPanel>
-                </Button>
-                <Button Style="{StaticResource MaterialDesignOutlinedButton}" 
-                    Margin="0 4 8 8"
-                    Command="{s:Action FlipColorStops}" 
-                    IsEnabled="{Binding HasMoreThanOneStop}" 
-                    HorizontalAlignment="Left"
-                    Height="25" Width="100" ToolTip="Flip Stops">
-                    <StackPanel Orientation="Horizontal">
-                        <materialDesign:PackIcon Kind="FlipHorizontal"/>
-                        <TextBlock Margin="6 0 0 0">Flip</TextBlock>
-                    </StackPanel>
-                </Button>
-            </StackPanel>
-            <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="0">
-                
-                <Button Style="{StaticResource MaterialDesignOutlinedButton}" 
-                    Margin="0 0 8 0"
-                    Command="{s:Action ToggleSeam}" 
-                    IsEnabled="{Binding HasMoreThanOneStop}" 
-                    HorizontalAlignment="Left"
-                    Height="25" Width="100" ToolTip="Toggle Seam">
-                    <StackPanel Orientation="Horizontal">
-                        <materialDesign:PackIcon Kind="ArrowSplitVertical"/>
-                        <TextBlock Margin="6 0 0 0">Seam</TextBlock>
-                    </StackPanel>
-                </Button>
-                <Button Style="{StaticResource MaterialDesignOutlinedButton}" 
-                    Margin="0 0 8 0"
-                    Command="{s:Action ClearGradient}" 
-                    IsEnabled="{Binding HasMoreThanOneStop}" 
-                    HorizontalAlignment="Left"
-                    Height="25" Width="100" ToolTip="Clear Gradient">
-                    <StackPanel Orientation="Horizontal">
-                        <materialDesign:PackIcon Kind="DeleteSweep"/>
-                        <TextBlock Margin="6 0 0 0">Clear</TextBlock>
-                    </StackPanel>
-                </Button>
-            </StackPanel>
-            
             <TextBlock Margin="0 6 0 0" FontWeight="Bold">Selected stop:</TextBlock>
 
             <Grid Margin="0 5">
@@ -170,7 +180,7 @@
 
                     <Label HorizontalAlignment="Center">Location:</Label>
                     <TextBox Width="30"
-                             Text="{Binding SelectedColorStopViewModel.OffsetPercent}"
+                             Text="{Binding SelectedColorStopViewModel.OffsetPercent, UpdateSourceTrigger=PropertyChanged}"
                              IsEnabled="{Binding HasSelectedColorStopViewModel}"
                              materialDesign:HintAssist.Hint="0"
                              Margin="5 0 0 0" />
@@ -184,6 +194,9 @@
                         Command="{s:Action RemoveColorStop}"
                         CommandParameter="{Binding SelectedColorStopViewModel}"
                         ToolTip="Delete Selected Stop">
+                    <Button.Resources>
+                        <SolidColorBrush x:Key="PrimaryHueMidBrush" Color="#c94848"/>
+                    </Button.Resources>
                     <StackPanel Orientation="Horizontal">
                         <materialDesign:PackIcon Kind="Delete"/>
                         <TextBlock Margin="4 0 0 0">Delete</TextBlock>

--- a/src/Artemis.UI.Shared/Screens/GradientEditor/GradientEditorViewModel.cs
+++ b/src/Artemis.UI.Shared/Screens/GradientEditor/GradientEditorViewModel.cs
@@ -30,18 +30,6 @@ namespace Artemis.UI.Shared.Screens.GradientEditor
             ColorStopViewModels.CollectionChanged += ColorStopViewModelsOnCollectionChanged;
         }
 
-        #region Overrides of DialogViewModelBase
-
-        /// <inheritdoc />
-        public override void OnDialogClosed(object sender, DialogClosingEventArgs e)
-        {
-            ColorGradient.CollectionChanged -= ColorGradientOnCollectionChanged;
-            ColorStopViewModels.CollectionChanged -= ColorStopViewModelsOnCollectionChanged;
-            base.OnDialogClosed(sender, e);
-        }
-
-        #endregion
-
         public BindableCollection<ColorStopViewModel> ColorStopViewModels { get; }
 
         public ColorStopViewModel? SelectedColorStopViewModel
@@ -65,10 +53,19 @@ namespace Artemis.UI.Shared.Screens.GradientEditor
             set => SetAndNotify(ref _previewWidth, value);
         }
 
-        public ColorGradient Stops
+        public ColorGradient Stops => ColorGradient;
+
+        #region Overrides of DialogViewModelBase
+
+        /// <inheritdoc />
+        public override void OnDialogClosed(object sender, DialogClosingEventArgs e)
         {
-            get => ColorGradient;
+            ColorGradient.CollectionChanged -= ColorGradientOnCollectionChanged;
+            ColorStopViewModels.CollectionChanged -= ColorStopViewModelsOnCollectionChanged;
+            base.OnDialogClosed(sender, e);
         }
+
+        #endregion
 
         public void AddColorStop(object sender, MouseEventArgs e)
         {
@@ -87,9 +84,6 @@ namespace Artemis.UI.Shared.Screens.GradientEditor
 
         public void RemoveColorStop(ColorStopViewModel colorStopViewModel)
         {
-            if (colorStopViewModel == null)
-                return;
-
             ColorStopViewModels.Remove(colorStopViewModel);
             ColorGradient.Remove(colorStopViewModel.ColorStop);
 
@@ -99,18 +93,18 @@ namespace Artemis.UI.Shared.Screens.GradientEditor
 
         public void SpreadColorStops()
         {
-            var stops = ColorStopViewModels.OrderBy(x => x.OffsetFloat);
+            List<ColorStopViewModel> stops = ColorStopViewModels.OrderBy(x => x.OffsetFloat).ToList();
             int index = 0;
             foreach (ColorStopViewModel stop in stops)
             {
-                stop.OffsetFloat = index / ((float)stops.Count() - 1);
+                stop.OffsetFloat = index / ((float) stops.Count - 1);
                 index++;
             }
         }
 
         public void RotateColorStops()
         {
-            var stops = ColorStopViewModels.OrderByDescending(x => x.OffsetFloat);
+            List<ColorStopViewModel> stops = ColorStopViewModels.OrderByDescending(x => x.OffsetFloat).ToList();
             float lastStopPosition = stops.Last().OffsetFloat;
             foreach (ColorStopViewModel stop in stops)
             {
@@ -122,10 +116,7 @@ namespace Artemis.UI.Shared.Screens.GradientEditor
 
         public void FlipColorStops()
         {
-            foreach (ColorStopViewModel stop in ColorStopViewModels)
-            {
-                stop.OffsetFloat = 1 - stop.OffsetFloat;
-            }
+            foreach (ColorStopViewModel stop in ColorStopViewModels) stop.OffsetFloat = 1 - stop.OffsetFloat;
         }
 
         public void ToggleSeam()
@@ -133,7 +124,7 @@ namespace Artemis.UI.Shared.Screens.GradientEditor
             if (ColorGradient.IsSeamless())
             {
                 // Remove the last stop
-                var stop = ColorStopViewModels.OrderBy(x => x.OffsetFloat).Last();
+                ColorStopViewModel? stop = ColorStopViewModels.OrderBy(x => x.OffsetFloat).Last();
 
                 if (stop == SelectedColorStopViewModel) SelectColorStop(null);
 
@@ -159,6 +150,7 @@ namespace Artemis.UI.Shared.Screens.GradientEditor
                 SpreadColorStops();
             }
         }
+
         public void ClearGradient()
         {
             ColorGradient.Clear();

--- a/src/Artemis.UI.Shared/Screens/GradientEditor/GradientEditorViewModel.cs
+++ b/src/Artemis.UI.Shared/Screens/GradientEditor/GradientEditorViewModel.cs
@@ -104,7 +104,12 @@ namespace Artemis.UI.Shared.Screens.GradientEditor
 
         public void RotateColorStops()
         {
-            List<ColorStopViewModel> stops = ColorStopViewModels.OrderByDescending(x => x.OffsetFloat).ToList();
+            List<ColorStopViewModel> stops;
+            if (Keyboard.IsKeyDown(Key.LeftShift) || Keyboard.IsKeyDown(Key.RightShift)) 
+                stops = ColorStopViewModels.OrderBy(x => x.OffsetFloat).ToList();
+            else 
+                stops = ColorStopViewModels.OrderByDescending(x => x.OffsetFloat).ToList();
+
             float lastStopPosition = stops.Last().OffsetFloat;
             foreach (ColorStopViewModel stop in stops)
             {


### PR DESCRIPTION
Adds a few different tools for users to more easily manipulate gradients. These are: Spread, Rotate, Flip, Toggle Seam, and Clear

It also makes a small tweak to the Color Picker textbox (monospace font to stop it from being covered by the color circle in low width scenarios).

Closes #564.