### PR TITLE
Fix null object exception

### DIFF
--- a/src/Artemis.Core/Plugins/Modules/ActivationRequirements/ProcessActivationRequirement.cs
+++ b/src/Artemis.Core/Plugins/Modules/ActivationRequirements/ProcessActivationRequirement.cs
@@ -22,7 +22,7 @@ namespace Artemis.Core.Modules
         /// <param name="location">The location of where the process must be running from (optional)</param>
         public ProcessActivationRequirement(string? processName, string? location = null)
         {
-            if (string.IsNullOrWhiteSpace(ProcessName) && string.IsNullOrWhiteSpace(Location))
+            if (string.IsNullOrWhiteSpace(processName) && string.IsNullOrWhiteSpace(location))
                 throw new ArgumentNullException($"Atleast one {nameof(processName)} and {nameof(location)} must not be null");
 
             // Let's not make a habit out of this :P


### PR DESCRIPTION
Fix this new bug:

Artemis.Core.ArtemisPluginException: Failed to instantiate feature
 ---> System.ArgumentNullException: Value cannot be null. (Parameter 'Atleast one processName and location must not be null')
   at new Artemis.Core.Modules.ProcessActivationRequirement(string processName, string location) in D:/Repos/Artemis/src/Artemis.Core/Plugins/Modules/ActivationRequirements/ProcessActivationRequirement.cs:line 26
   at new Artemis.Plugins.DataModelExpansions.YTMdesktop.YTMdesktopDataModelExpansion(ILogger logger, IColorQuantizerService colorQuantizer, IProcessMonitorService processMonitorService)
   at object DynamicInjector580319bcefcf4e239d2054774f211e86(object[])
   at object Ninject.Activation.Providers.StandardProvider.Create(IContext context)
   at object Ninject.Activation.Context.ResolveInternal(object scope)
   at object Ninject.Activation.Context.Resolve()
   at IEnumerable<object> Ninject.KernelBase.Resolve(IRequest request, bool handleMissingBindings) x 2
   at IEnumerable<object> Ninject.Extensions.ChildKernel.ChildKernel.Resolve(IRequest request)
   at IEnumerable<object> Ninject.ResolutionExtensions.GetResolutionIterator(IResolutionRoot root, Type service, Func<IBindingMetadata, bool> constraint, IEnumerable<IParameter> parameters, bool isOptional, bool isUnique)
   at void Artemis.Core.Services.PluginManagementService.EnablePlugin(Plugin plugin, bool saveState, bool ignorePluginLock) in D:/Repos/Artemis/src/Artemis.Core/Services/PluginManagementService.cs:line 421
   --- End of inner exception stack trace ---

