### PR TITLE
Fix access denied exception

### DIFF
--- a/src/Artemis.Core/Plugins/Modules/ActivationRequirements/ProcessActivationRequirement.cs
+++ b/src/Artemis.Core/Plugins/Modules/ActivationRequirements/ProcessActivationRequirement.cs
@@ -50,13 +50,13 @@ namespace Artemis.Core.Modules
             if (ProcessName == null && Location == null)
                 return false;
 
-            IEnumerable<Process> processes = _processMonitorService.GetRunningProcesses().Where(p => !p.HasExited);
+            IEnumerable<Process> processes = _processMonitorService.GetRunningProcesses();
             if (ProcessName != null)
                 processes = processes.Where(p => string.Equals(p.ProcessName, ProcessName, StringComparison.InvariantCultureIgnoreCase));
             if (Location != null)
                 processes = processes.Where(p => string.Equals(Path.GetDirectoryName(p.GetProcessFilename()), Location, StringComparison.InvariantCultureIgnoreCase));
 
-            return processes.Any();
+            return processes.Where(p => !p.HasExited).Any();
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
Fixes https://github.com/Artemis-RGB/Artemis/issues/619 by checking the processName before IsHalted (same way as the previous ProcessActivationRequirement version worked)