### PR TITLE
ColorQuantizer - Added FindAllColorVariations method

### DIFF
--- a/src/Artemis.Core/Services/ColorQuantizer/ColorSwatch.cs
+++ b/src/Artemis.Core/Services/ColorQuantizer/ColorSwatch.cs
@@ -1,0 +1,40 @@
+﻿using SkiaSharp;
+
+namespace Artemis.Core.Services
+{
+    /// <summary>
+    /// Swatch containing the known useful color variations.
+    /// </summary>
+    public struct ColorSwatch
+    {
+        /// <summary>
+        /// The <see cref="ColorType.Vibrant"/> component.
+        /// </summary>
+        public SKColor Vibrant { get; init; }
+
+        /// <summary>
+        /// The <see cref="ColorType.LightVibrant"/> component.
+        /// </summary>
+        public SKColor LightVibrant { get; init; }
+
+        /// <summary>
+        /// The <see cref="ColorType.DarkVibrant"/> component.
+        /// </summary>
+        public SKColor DarkVibrant { get; init; }
+
+        /// <summary>
+        /// The <see cref="ColorType.Muted"/> component.
+        /// </summary>
+        public SKColor Muted { get; init; }
+
+        /// <summary>
+        /// The <see cref="ColorType.LightMuted"/> component.
+        /// </summary>
+        public SKColor LightMuted { get; init; }
+
+        /// <summary>
+        /// The <see cref="ColorType.DarkMuted"/> component.
+        /// </summary>
+        public SKColor DarkMuted { get; init; }
+    }
+}

--- a/src/Artemis.Core/Services/ColorQuantizer/Interfaces/IColorQuantizerService.cs
+++ b/src/Artemis.Core/Services/ColorQuantizer/Interfaces/IColorQuantizerService.cs
@@ -26,5 +26,13 @@ namespace Artemis.Core.Services
         /// <param name="ignoreLimits">Ignore hard limits on whether a color is considered for each category. Result may be <see cref="SKColor.Empty"/> if this is false</param>
         /// <returns>The color found</returns>
         public SKColor FindColorVariation(IEnumerable<SKColor> colors, ColorType type, bool ignoreLimits = false);
+
+        /// <summary>
+        /// Finds all the color variations available and returns a struct containing them all.
+        /// </summary>
+        /// <param name="colors">The colors to find the variations in</param>
+        /// <param name="ignoreLimits">Ignore hard limits on whether a color is considered for each category. Some colors may be <see cref="SKColor.Empty"/> if this is false</param>
+        /// <returns>A swatch containing all color variations</returns>
+        public ColorSwatch FindAllColorVariations(IEnumerable<SKColor> colors, bool ignoreLimits = false);
     }
 }


### PR DESCRIPTION
This adds a method that returns all the found color variations at once as a struct instead of the user having to get them all.
It's also slightly faster since it only iterates through the colors enumerable once for all the variations instead of once per variation.
The ColorSwatch struct contains all the colors that can be reused by all plugins instead of each one having a custom DataModel.
 
I considered adding a function that accepts a URL to an image and returns the swatch with its color, but it seemed a bit out of scope for the service.