### PR TITLE
Core - replaced AsReadOnly calls in get only properties

### DIFF
--- a/src/Artemis.Core/Models/Profile/Conditions/Abstract/DataModelConditionPart.cs
+++ b/src/Artemis.Core/Models/Profile/Conditions/Abstract/DataModelConditionPart.cs
@@ -13,6 +13,11 @@ namespace Artemis.Core
     {
         private readonly List<DataModelConditionPart> _children = new();
 
+        protected DataModelConditionPart()
+        {
+            Children = new(_children);
+        }
+
         /// <summary>
         ///     Gets the parent of this part
         /// </summary>
@@ -21,7 +26,7 @@ namespace Artemis.Core
         /// <summary>
         ///     Gets the children of this part
         /// </summary>
-        public ReadOnlyCollection<DataModelConditionPart> Children => _children.AsReadOnly();
+        public ReadOnlyCollection<DataModelConditionPart> Children { get; }
 
         /// <summary>
         ///     Adds a child to the display condition part's <see cref="Children" /> collection

--- a/src/Artemis.Core/Models/Profile/DataBindings/Modes/Conditional/ConditionalDataBinding.cs
+++ b/src/Artemis.Core/Models/Profile/DataBindings/Modes/Conditional/ConditionalDataBinding.cs
@@ -18,13 +18,14 @@ namespace Artemis.Core
         {
             DataBinding = dataBinding;
             Entity = entity;
+            Conditions = new(_conditions);
             Load();
         }
 
         /// <summary>
         ///     Gets a list of conditions applied to this data binding
         /// </summary>
-        public ReadOnlyCollection<DataBindingCondition<TLayerProperty, TProperty>> Conditions => _conditions.AsReadOnly();
+        public ReadOnlyCollection<DataBindingCondition<TLayerProperty, TProperty>> Conditions { get; }
 
         internal ConditionalDataBindingEntity Entity { get; }
 

--- a/src/Artemis.Core/Models/Profile/DataBindings/Modes/DirectDataBinding.cs
+++ b/src/Artemis.Core/Models/Profile/DataBindings/Modes/DirectDataBinding.cs
@@ -17,7 +17,7 @@ namespace Artemis.Core
         {
             DataBinding = dataBinding;
             Entity = entity;
-
+            Modifiers = new(_modifiers);
             Load();
         }
 
@@ -29,7 +29,7 @@ namespace Artemis.Core
         /// <summary>
         ///     Gets a list of modifiers applied to this data binding
         /// </summary>
-        public ReadOnlyCollection<DataBindingModifier<TLayerProperty, TProperty>> Modifiers => _modifiers.AsReadOnly();
+        public ReadOnlyCollection<DataBindingModifier<TLayerProperty, TProperty>> Modifiers { get; }
 
         internal DirectDataBindingEntity Entity { get; }
 

--- a/src/Artemis.Core/Models/Profile/Folder.cs
+++ b/src/Artemis.Core/Models/Profile/Folder.cs
@@ -306,7 +306,7 @@ namespace Artemis.Core
                 ChildrenList.Add(new Layer(Profile, this, childLayer));
 
             // Ensure order integrity, should be unnecessary but no one is perfect specially me
-            ChildrenList = ChildrenList.OrderBy(c => c.Order).ToList();
+            ChildrenList.Sort((a,b) => a.Order.CompareTo(b.Order));
             for (int index = 0; index < ChildrenList.Count; index++)
                 ChildrenList[index].Order = index + 1;
 

--- a/src/Artemis.Core/Models/Profile/Layer.cs
+++ b/src/Artemis.Core/Models/Profile/Layer.cs
@@ -43,6 +43,7 @@ namespace Artemis.Core
             _transform = new LayerTransformProperties();
 
             _leds = new List<ArtemisLed>();
+            Leds = new ReadOnlyCollection<ArtemisLed>(_leds);
 
             Adapter = new LayerAdapter(this);
             Initialize();
@@ -67,6 +68,7 @@ namespace Artemis.Core
             _transform = new LayerTransformProperties();
 
             _leds = new List<ArtemisLed>();
+            Leds = new ReadOnlyCollection<ArtemisLed>(_leds);
 
             Adapter = new LayerAdapter(this);
             Load();
@@ -76,7 +78,7 @@ namespace Artemis.Core
         /// <summary>
         ///     A collection of all the LEDs this layer is assigned to.
         /// </summary>
-        public ReadOnlyCollection<ArtemisLed> Leds => _leds.AsReadOnly();
+        public ReadOnlyCollection<ArtemisLed> Leds { get; private set; }
 
         /// <summary>
         ///     Defines the shape that is rendered by the <see cref="LayerBrush" />.
@@ -679,6 +681,7 @@ namespace Artemis.Core
             }
 
             _leds = leds;
+            Leds = new ReadOnlyCollection<ArtemisLed>(_leds);
             CalculateRenderProperties();
         }
 

--- a/src/Artemis.Core/Models/Profile/LayerProperties/LayerProperty.cs
+++ b/src/Artemis.Core/Models/Profile/LayerProperties/LayerProperty.cs
@@ -44,6 +44,7 @@ namespace Artemis.Core
                 _baseValue = default!;
 
             _keyframes = new List<LayerPropertyKeyframe<T>>();
+            Keyframes = new(_keyframes);
         }
 
         /// <summary>
@@ -337,7 +338,7 @@ namespace Artemis.Core
         #region Keyframes
 
         private bool _keyframesEnabled;
-        private List<LayerPropertyKeyframe<T>> _keyframes;
+        private readonly List<LayerPropertyKeyframe<T>> _keyframes;
 
         /// <summary>
         ///     Gets whether keyframes are supported on this type of property
@@ -363,7 +364,7 @@ namespace Artemis.Core
         /// <summary>
         ///     Gets a read-only list of all the keyframes on this layer property
         /// </summary>
-        public ReadOnlyCollection<LayerPropertyKeyframe<T>> Keyframes => _keyframes.AsReadOnly();
+        public ReadOnlyCollection<LayerPropertyKeyframe<T>> Keyframes { get; }
 
         /// <summary>
         ///     Gets the current keyframe in the timeline according to the current progress
@@ -436,7 +437,7 @@ namespace Artemis.Core
         /// </summary>
         internal void SortKeyframes()
         {
-            _keyframes = _keyframes.OrderBy(k => k.Position).ToList();
+            _keyframes.Sort((a, b) => a.Position.CompareTo(b.Position));
         }
 
         private void UpdateKeyframes(Timeline timeline)

--- a/src/Artemis.Core/Models/Profile/LayerPropertyGroup.cs
+++ b/src/Artemis.Core/Models/Profile/LayerPropertyGroup.cs
@@ -37,6 +37,9 @@ namespace Artemis.Core
 
             _layerProperties = new List<ILayerProperty>();
             _layerPropertyGroups = new List<LayerPropertyGroup>();
+
+            LayerProperties = new(_layerProperties);
+            LayerPropertyGroups = new(_layerPropertyGroups);
         }
 
         /// <summary>
@@ -96,12 +99,12 @@ namespace Artemis.Core
         /// <summary>
         ///     A list of all layer properties in this group
         /// </summary>
-        public ReadOnlyCollection<ILayerProperty> LayerProperties => _layerProperties.AsReadOnly();
+        public ReadOnlyCollection<ILayerProperty> LayerProperties { get; }
 
         /// <summary>
         ///     A list of al child groups in this group
         /// </summary>
-        public ReadOnlyCollection<LayerPropertyGroup> LayerPropertyGroups => _layerPropertyGroups.AsReadOnly();
+        public ReadOnlyCollection<LayerPropertyGroup> LayerPropertyGroups { get; }
 
         /// <summary>
         ///     Recursively gets all layer properties on this group and any subgroups

--- a/src/Artemis.Core/Models/Profile/ProfileCategory.cs
+++ b/src/Artemis.Core/Models/Profile/ProfileCategory.cs
@@ -24,12 +24,15 @@ namespace Artemis.Core
         {
             _name = name;
             Entity = new ProfileCategoryEntity();
+            ProfileConfigurations = new(_profileConfigurations);
         }
 
         internal ProfileCategory(ProfileCategoryEntity entity)
         {
             _name = null!;
             Entity = entity;
+            ProfileConfigurations = new(_profileConfigurations);
+
             Load();
         }
 
@@ -73,7 +76,7 @@ namespace Artemis.Core
         /// <summary>
         ///     Gets a read only collection of the profiles inside this category
         /// </summary>
-        public ReadOnlyCollection<ProfileConfiguration> ProfileConfigurations => _profileConfigurations.AsReadOnly();
+        public ReadOnlyCollection<ProfileConfiguration> ProfileConfigurations { get; }
 
         /// <summary>
         ///     Gets the unique ID of this category

--- a/src/Artemis.Core/Models/Profile/ProfileElement.cs
+++ b/src/Artemis.Core/Models/Profile/ProfileElement.cs
@@ -18,12 +18,13 @@ namespace Artemis.Core
         private Profile _profile;
         private bool _suspended;
 
-        internal List<ProfileElement> ChildrenList;
+        internal readonly List<ProfileElement> ChildrenList;
 
         internal ProfileElement(Profile profile)
         {
             _profile = profile;
             ChildrenList = new List<ProfileElement>();
+            Children = new(ChildrenList);
         }
 
         /// <summary>
@@ -56,16 +57,7 @@ namespace Artemis.Core
         /// <summary>
         ///     The element's children
         /// </summary>
-        public ReadOnlyCollection<ProfileElement> Children
-        {
-            get
-            {
-                lock (ChildrenList)
-                {
-                    return ChildrenList.AsReadOnly();
-                }
-            }
-        }
+        public ReadOnlyCollection<ProfileElement> Children { get; }
 
         /// <summary>
         ///     The order in which this element appears in the update loop and editor

--- a/src/Artemis.Core/Models/Profile/RenderProfileElement.cs
+++ b/src/Artemis.Core/Models/Profile/RenderProfileElement.cs
@@ -24,6 +24,7 @@ namespace Artemis.Core
             Timeline = new Timeline();
             ExpandedPropertyGroups = new List<string>();
             LayerEffectsList = new List<BaseLayerEffect>();
+            LayerEffects = new(LayerEffectsList);
 
             LayerEffectStore.LayerEffectAdded += LayerEffectStoreOnLayerEffectAdded;
             LayerEffectStore.LayerEffectRemoved += LayerEffectStoreOnLayerEffectRemoved;
@@ -223,12 +224,12 @@ namespace Artemis.Core
 
         #region Effect management
 
-        internal List<BaseLayerEffect> LayerEffectsList;
+        internal readonly List<BaseLayerEffect> LayerEffectsList;
 
         /// <summary>
         ///     Gets a read-only collection of the layer effects on this entity
         /// </summary>
-        public ReadOnlyCollection<BaseLayerEffect> LayerEffects => LayerEffectsList.AsReadOnly();
+        public ReadOnlyCollection<BaseLayerEffect> LayerEffects { get; }
 
         /// <summary>
         ///     Adds a the layer effect described inthe provided <paramref name="descriptor" />

--- a/src/Artemis.Core/Models/Profile/Timeline.cs
+++ b/src/Artemis.Core/Models/Profile/Timeline.cs
@@ -24,6 +24,7 @@ namespace Artemis.Core
             MainSegmentLength = TimeSpan.FromSeconds(5);
 
             _extraTimelines = new List<Timeline>();
+            ExtraTimelines = new(_extraTimelines);
 
             Save();
         }
@@ -32,6 +33,7 @@ namespace Artemis.Core
         {
             Entity = entity;
             _extraTimelines = new List<Timeline>();
+            ExtraTimelines = new(_extraTimelines);
 
             Load();
         }
@@ -45,6 +47,7 @@ namespace Artemis.Core
             EndSegmentLength = Parent.EndSegmentLength;
 
             _extraTimelines = new List<Timeline>();
+            ExtraTimelines = new(_extraTimelines);
         }
 
         /// <inheritdoc />
@@ -150,7 +153,7 @@ namespace Artemis.Core
         /// <summary>
         ///     Gets a list of extra copies of the timeline applied to this timeline
         /// </summary>
-        public ReadOnlyCollection<Timeline> ExtraTimelines => _extraTimelines.AsReadOnly();
+        public ReadOnlyCollection<Timeline> ExtraTimelines { get; }
 
         /// <summary>
         ///     Gets a boolean indicating whether the timeline has finished its run

--- a/src/Artemis.Core/Plugins/LayerBrushes/LayerBrushProvider.cs
+++ b/src/Artemis.Core/Plugins/LayerBrushes/LayerBrushProvider.cs
@@ -17,13 +17,14 @@ namespace Artemis.Core.LayerBrushes
         protected LayerBrushProvider()
         {
             _layerBrushDescriptors = new List<LayerBrushDescriptor>();
+            LayerBrushDescriptors = new(_layerBrushDescriptors);
             Disabled += OnDisabled;
         }
 
         /// <summary>
         ///     A read-only collection of all layer brushes added with <see cref="RegisterLayerBrushDescriptor{T}" />
         /// </summary>
-        public ReadOnlyCollection<LayerBrushDescriptor> LayerBrushDescriptors => _layerBrushDescriptors.AsReadOnly();
+        public ReadOnlyCollection<LayerBrushDescriptor> LayerBrushDescriptors { get; }
 
         /// <summary>
         ///     Registers a layer brush descriptor for a given layer brush, so that it appears in the UI.

--- a/src/Artemis.Core/Plugins/LayerEffects/LayerEffectProvider.cs
+++ b/src/Artemis.Core/Plugins/LayerEffects/LayerEffectProvider.cs
@@ -18,13 +18,14 @@ namespace Artemis.Core.LayerEffects
         protected LayerEffectProvider()
         {
             _layerEffectDescriptors = new List<LayerEffectDescriptor>();
+            LayerEffectDescriptors = new(_layerEffectDescriptors);
             Disabled += OnDisabled;
         }
 
         /// <summary>
         ///     A read-only collection of all layer effects added with <see cref="RegisterLayerEffectDescriptor{T}" />
         /// </summary>
-        public ReadOnlyCollection<LayerEffectDescriptor> LayerEffectDescriptors => _layerEffectDescriptors.AsReadOnly();
+        public ReadOnlyCollection<LayerEffectDescriptor> LayerEffectDescriptors { get; }
 
         /// <summary>
         ///     Adds a layer effect descriptor for a given layer effect, so that it appears in the UI.

--- a/src/Artemis.Core/Plugins/Modules/DataModel.cs
+++ b/src/Artemis.Core/Plugins/Modules/DataModel.cs
@@ -26,6 +26,9 @@ namespace Artemis.Core.Modules
             // These are both set right after construction to keep the constructor of inherited classes clean
             Module = null!;
             DataModelDescription = null!;
+
+            ActivePaths = new(_activePaths);
+            DynamicChildren = new(_dynamicChildren);
         }
 
         /// <summary>
@@ -52,13 +55,13 @@ namespace Artemis.Core.Modules
         ///     Gets an read-only dictionary of all dynamic children
         /// </summary>
         [DataModelIgnore]
-        public ReadOnlyDictionary<string, DynamicChild> DynamicChildren => new(_dynamicChildren);
+        public ReadOnlyDictionary<string, DynamicChild> DynamicChildren { get; }
 
         /// <summary>
         ///     Gets a read-only list of <see cref="DataModelPath" />s targeting this data model
         /// </summary>
         [DataModelIgnore]
-        public ReadOnlyCollection<DataModelPath> ActivePaths => _activePaths.AsReadOnly();
+        public ReadOnlyCollection<DataModelPath> ActivePaths { get; }
 
         /// <summary>
         ///     Returns a read-only collection of all properties in this datamodel that are to be ignored

--- a/src/Artemis.Core/Plugins/Modules/Module.cs
+++ b/src/Artemis.Core/Plugins/Modules/Module.cs
@@ -114,7 +114,7 @@ namespace Artemis.Core.Modules
         private readonly List<(DefaultCategoryName, string)> _defaultProfilePaths = new();
         private readonly List<(DefaultCategoryName, string)> _pendingDefaultProfilePaths = new();
 
-        public Module()
+        protected Module()
         {
             DefaultProfilePaths = new ReadOnlyCollection<(DefaultCategoryName, string)>(_defaultProfilePaths);
             HiddenProperties = new(HiddenPropertiesList);

--- a/src/Artemis.Core/Plugins/Modules/Module.cs
+++ b/src/Artemis.Core/Plugins/Modules/Module.cs
@@ -114,6 +114,12 @@ namespace Artemis.Core.Modules
         private readonly List<(DefaultCategoryName, string)> _defaultProfilePaths = new();
         private readonly List<(DefaultCategoryName, string)> _pendingDefaultProfilePaths = new();
 
+        public Module()
+        {
+            DefaultProfilePaths = new ReadOnlyCollection<(DefaultCategoryName, string)>(_defaultProfilePaths);
+            HiddenProperties = new(HiddenPropertiesList);
+        }
+
         /// <summary>
         ///     Gets a list of all properties ignored at runtime using <c>IgnoreProperty(x => x.y)</c>
         /// </summary>
@@ -122,7 +128,7 @@ namespace Artemis.Core.Modules
         /// <summary>
         ///     Gets a read only collection of default profile paths
         /// </summary>
-        public IReadOnlyCollection<(DefaultCategoryName, string)> DefaultProfilePaths => _defaultProfilePaths.AsReadOnly();
+        public IReadOnlyCollection<(DefaultCategoryName, string)> DefaultProfilePaths { get; }
 
         /// <summary>
         ///     A list of activation requirements
@@ -176,7 +182,7 @@ namespace Artemis.Core.Modules
         /// <summary>
         ///     Gets a list of all properties ignored at runtime using <c>IgnoreProperty(x => x.y)</c>
         /// </summary>
-        public ReadOnlyCollection<PropertyInfo> HiddenProperties => HiddenPropertiesList.AsReadOnly();
+        public ReadOnlyCollection<PropertyInfo> HiddenProperties { get; }
 
         internal DataModel? InternalDataModel { get; set; }
 

--- a/src/Artemis.Core/Plugins/Plugin.cs
+++ b/src/Artemis.Core/Plugins/Plugin.cs
@@ -30,6 +30,9 @@ namespace Artemis.Core
 
             _features = new List<PluginFeatureInfo>();
             _profilers = new List<Profiler>();
+
+            Features = new(_features);
+            Profilers = new(_profilers);
         }
 
         /// <summary>
@@ -64,12 +67,12 @@ namespace Artemis.Core
         /// <summary>
         ///     Gets a read-only collection of all features this plugin provides
         /// </summary>
-        public ReadOnlyCollection<PluginFeatureInfo> Features => _features.AsReadOnly();
+        public ReadOnlyCollection<PluginFeatureInfo> Features { get; }
 
         /// <summary>
         ///     Gets a read-only collection of profiles running on the plugin
         /// </summary>
-        public ReadOnlyCollection<Profiler> Profilers => _profilers.AsReadOnly();
+        public ReadOnlyCollection<Profiler> Profilers { get; }
 
         /// <summary>
         ///     The assembly the plugin code lives in

--- a/src/Artemis.Core/Plugins/ScriptingProviders/ScriptingProvider.cs
+++ b/src/Artemis.Core/Plugins/ScriptingProviders/ScriptingProvider.cs
@@ -44,6 +44,11 @@ namespace Artemis.Core.ScriptingProviders
     /// </summary>
     public abstract class ScriptingProvider : PluginFeature
     {
+        protected ScriptingProvider()
+        {
+            Scripts = new(InternalScripts);
+        }
+
         /// <summary>
         ///     Gets the name of the scripting language this provider provides
         /// </summary>
@@ -52,7 +57,7 @@ namespace Artemis.Core.ScriptingProviders
         /// <summary>
         ///     Gets a list of all active scripts belonging to this scripting provider
         /// </summary>
-        public ReadOnlyCollection<Script> Scripts => InternalScripts.AsReadOnly();
+        public ReadOnlyCollection<Script> Scripts { get; }
 
         internal abstract Type GlobalScriptType { get; }
         internal abstract Type ProfileScriptType { get; }

--- a/src/Artemis.Core/Services/RgbService.cs
+++ b/src/Artemis.Core/Services/RgbService.cs
@@ -49,6 +49,10 @@ namespace Artemis.Core.Services
             _devices = new List<ArtemisDevice>();
             _ledMap = new Dictionary<Led, ArtemisLed>();
 
+            EnabledDevices = new ReadOnlyCollection<ArtemisDevice>(_enabledDevices);
+            Devices = new ReadOnlyCollection<ArtemisDevice>(_devices);
+            LedMap = new ReadOnlyDictionary<Led, ArtemisLed>(_ledMap);
+
             UpdateTrigger = new TimerUpdateTrigger {UpdateFrequency = 1.0 / _targetFrameRateSetting.Value};
             SetRenderPaused(true);
             Surface.RegisterUpdateTrigger(UpdateTrigger);
@@ -132,9 +136,9 @@ namespace Artemis.Core.Services
             _texture?.Invalidate();
         }
 
-        public IReadOnlyCollection<ArtemisDevice> EnabledDevices => _enabledDevices.AsReadOnly();
-        public IReadOnlyCollection<ArtemisDevice> Devices => _devices.AsReadOnly();
-        public IReadOnlyDictionary<Led, ArtemisLed> LedMap => new ReadOnlyDictionary<Led, ArtemisLed>(_ledMap);
+        public IReadOnlyCollection<ArtemisDevice> EnabledDevices { get; }
+        public IReadOnlyCollection<ArtemisDevice> Devices { get; }
+        public IReadOnlyDictionary<Led, ArtemisLed> LedMap { get; }
 
         public RGBSurface Surface { get; set; }
         public bool IsRenderPaused { get; set; }

--- a/src/Artemis.Core/Services/RgbService.cs
+++ b/src/Artemis.Core/Services/RgbService.cs
@@ -89,6 +89,7 @@ namespace Artemis.Core.Services
             try
             {
                 _ledMap = new Dictionary<Led, ArtemisLed>(_devices.SelectMany(d => d.Leds).ToDictionary(l => l.RgbLed));
+                LedMap = new ReadOnlyDictionary<Led, ArtemisLed>(_ledMap);
 
                 if (_surfaceLedGroup == null)
                 {
@@ -138,7 +139,7 @@ namespace Artemis.Core.Services
 
         public IReadOnlyCollection<ArtemisDevice> EnabledDevices { get; }
         public IReadOnlyCollection<ArtemisDevice> Devices { get; }
-        public IReadOnlyDictionary<Led, ArtemisLed> LedMap { get; }
+        public IReadOnlyDictionary<Led, ArtemisLed> LedMap { get; private set; }
 
         public RGBSurface Surface { get; set; }
         public bool IsRenderPaused { get; set; }

--- a/src/Artemis.Core/Services/ScriptingService.cs
+++ b/src/Artemis.Core/Services/ScriptingService.cs
@@ -24,6 +24,7 @@ namespace Artemis.Core.Services
             _profileService = profileService;
 
             InternalGlobalScripts = new List<GlobalScript>();
+            GlobalScripts = new(InternalGlobalScripts);
 
             _pluginManagementService.PluginFeatureEnabled += PluginManagementServiceOnPluginFeatureToggled;
             _pluginManagementService.PluginFeatureDisabled += PluginManagementServiceOnPluginFeatureToggled;
@@ -80,7 +81,7 @@ namespace Artemis.Core.Services
                 CreateScriptInstance(profile, scriptConfiguration);
         }
 
-        public ReadOnlyCollection<GlobalScript> GlobalScripts => InternalGlobalScripts.AsReadOnly();
+        public ReadOnlyCollection<GlobalScript> GlobalScripts { get; }
 
         public GlobalScript? CreateScriptInstance(ScriptConfiguration scriptConfiguration)
         {

--- a/src/Artemis.UI.Shared/Services/DataModelUIService.cs
+++ b/src/Artemis.UI.Shared/Services/DataModelUIService.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Linq;
 using Artemis.Core;
 using Artemis.Core.Modules;
@@ -26,10 +27,13 @@ namespace Artemis.UI.Shared.Services
             _kernel = kernel;
             _registeredDataModelEditors = new List<DataModelVisualizationRegistration>();
             _registeredDataModelDisplays = new List<DataModelVisualizationRegistration>();
+
+            RegisteredDataModelEditors = new ReadOnlyCollection<DataModelVisualizationRegistration>(_registeredDataModelEditors);
+            RegisteredDataModelDisplays = new ReadOnlyCollection<DataModelVisualizationRegistration>(_registeredDataModelDisplays);
         }
 
-        public IReadOnlyCollection<DataModelVisualizationRegistration> RegisteredDataModelEditors => _registeredDataModelEditors.AsReadOnly();
-        public IReadOnlyCollection<DataModelVisualizationRegistration> RegisteredDataModelDisplays => _registeredDataModelDisplays.AsReadOnly();
+        public IReadOnlyCollection<DataModelVisualizationRegistration> RegisteredDataModelEditors { get; }
+        public IReadOnlyCollection<DataModelVisualizationRegistration> RegisteredDataModelDisplays { get; }
 
         public DataModelPropertiesViewModel GetMainDataModelVisualization()
         {

--- a/src/Artemis.UI.Shared/Services/ProfileEditorService.cs
+++ b/src/Artemis.UI.Shared/Services/ProfileEditorService.cs
@@ -39,6 +39,8 @@ namespace Artemis.UI.Shared.Services
             _rgbService = rgbService;
             _moduleService = moduleService;
             _registeredPropertyEditors = new List<PropertyInputRegistration>();
+
+            RegisteredPropertyEditors = new(_registeredPropertyEditors);
             coreService.FrameRendered += CoreServiceOnFrameRendered;
             PixelsPerSecond = 100;
         }
@@ -103,7 +105,7 @@ namespace Artemis.UI.Shared.Services
             }
         }
 
-        public ReadOnlyCollection<PropertyInputRegistration> RegisteredPropertyEditors => _registeredPropertyEditors.AsReadOnly();
+        public ReadOnlyCollection<PropertyInputRegistration> RegisteredPropertyEditors { get; }
 
         public bool Playing { get; set; }
 


### PR DESCRIPTION
This should reduce allocations since we're not allocating a new ReadOnlyCollection each time the property is accessed. I have not tested thos very thoroughly but it seems fine.