### PR TITLE
Fix LayerEffect order double variable assignment

### DIFF
--- a/src/Artemis.Core/Models/Profile/RenderProfileElement.cs
+++ b/src/Artemis.Core/Models/Profile/RenderProfileElement.cs
@@ -273,7 +273,7 @@ namespace Artemis.Core
             int index = 0;
             foreach (BaseLayerEffect baseLayerEffect in LayerEffects.OrderBy(e => e.Order))
             {
-                baseLayerEffect.Order = Order = index + 1;
+                baseLayerEffect.Order = index + 1;
                 index++;
             }
 


### PR DESCRIPTION
This fixes the accidental double assignment of the LayerEffect order messing up more complex profiles.
Closes #669