### PR TITLE
Nodes Core - Object output pins

### DIFF
--- a/src/Artemis.Core/Models/Profile/Conditions/EventCondition.cs
+++ b/src/Artemis.Core/Models/Profile/Conditions/EventCondition.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Linq;
 using Artemis.Core.Internal;
-using Artemis.Core.VisualScripting.Internal;
 using Artemis.Storage.Entities.Profile.Abstract;
 using Artemis.Storage.Entities.Profile.Conditions;
 

--- a/src/Artemis.Core/Models/Profile/Conditions/EventOverlapMode.cs
+++ b/src/Artemis.Core/Models/Profile/Conditions/EventOverlapMode.cs
@@ -1,0 +1,23 @@
+namespace Artemis.Core;
+
+/// <summary>
+///     Represents a mode for render elements to configure the behaviour of events that overlap i.e. trigger again before
+///     the timeline finishes.
+/// </summary>
+public enum EventOverlapMode
+{
+    /// <summary>
+    ///     Stop the current run and restart the timeline
+    /// </summary>
+    Restart,
+
+    /// <summary>
+    ///     Play another copy of the timeline on top of the current run
+    /// </summary>
+    Copy,
+
+    /// <summary>
+    ///     Ignore subsequent event fires until the timeline finishes
+    /// </summary>
+    Ignore
+}

--- a/src/Artemis.Core/Models/Profile/Conditions/EventToggleOffMode.cs
+++ b/src/Artemis.Core/Models/Profile/Conditions/EventToggleOffMode.cs
@@ -1,0 +1,18 @@
+namespace Artemis.Core;
+
+/// <summary>
+///     Represents a mode for render elements when toggling off the event when using <see cref="EventTriggerMode.Toggle" />
+///     .
+/// </summary>
+public enum EventToggleOffMode
+{
+    /// <summary>
+    ///     When the event toggles the condition off, finish the the current run of the main timeline
+    /// </summary>
+    Finish,
+
+    /// <summary>
+    ///     When the event toggles the condition off, skip to the end segment of the timeline
+    /// </summary>
+    SkipToEnd
+}

--- a/src/Artemis.Core/Models/Profile/Conditions/EventTriggerMode.cs
+++ b/src/Artemis.Core/Models/Profile/Conditions/EventTriggerMode.cs
@@ -1,0 +1,17 @@
+namespace Artemis.Core;
+
+/// <summary>
+///     Represents a mode for render elements to start their timeline when display conditions events are fired.
+/// </summary>
+public enum EventTriggerMode
+{
+    /// <summary>
+    ///     Play the timeline once.
+    /// </summary>
+    Play,
+
+    /// <summary>
+    ///     Toggle repeating the timeline.
+    /// </summary>
+    Toggle
+}

--- a/src/Artemis.Core/Services/Input/InputProvider.cs
+++ b/src/Artemis.Core/Services/Input/InputProvider.cs
@@ -8,6 +8,13 @@ namespace Artemis.Core.Services;
 /// </summary>
 public abstract class InputProvider : IDisposable
 {
+    public InputProvider()
+    {
+        ProviderName = GetType().FullName ?? throw new InvalidOperationException("Input provider must have a type with a name");
+    }
+
+    internal string ProviderName { get; set; }
+
     /// <summary>
     ///     Called when the input service requests a <see cref="KeyboardToggleStatusReceived" /> event
     /// </summary>

--- a/src/Artemis.Core/VisualScripting/DefaultNode.cs
+++ b/src/Artemis.Core/VisualScripting/DefaultNode.cs
@@ -1,18 +1,11 @@
 ﻿using System;
 
-namespace Artemis.Core.Internal;
-
-/// <summary>
-///     Represents a kind of node that cannot be deleted inside a <see cref="INode" />.
-/// </summary>
-public interface IDefaultNode : INode
-{
-}
+namespace Artemis.Core;
 
 /// <summary>
 ///     Represents a kind of node that cannot be deleted inside a <see cref="NodeScript" />.
 /// </summary>
-public abstract class DefaultNode : Node, IDefaultNode
+public abstract class DefaultNode : Node
 {
     #region Constructors
 
@@ -20,8 +13,6 @@ public abstract class DefaultNode : Node, IDefaultNode
     protected DefaultNode(Guid id, string name, string description = "") : base(name, description)
     {
         Id = id;
-        Name = name;
-        Description = description;
     }
 
     #endregion

--- a/src/Artemis.Core/VisualScripting/Internal/EventConditionEventStartNode.cs
+++ b/src/Artemis.Core/VisualScripting/Internal/EventConditionEventStartNode.cs
@@ -1,23 +1,16 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Linq.Expressions;
-using System.Reflection;
-using Artemis.Core.Modules;
-using Artemis.Core.VisualScripting.Internal;
-using Humanizer;
 
 namespace Artemis.Core.Internal;
 
 internal class EventConditionEventStartNode : DefaultNode, IEventConditionNode
 {
     internal static readonly Guid NodeId = new("278735FE-69E9-4A73-A6B8-59E83EE19305");
-    private readonly Dictionary<Func<DataModelEventArgs, object>, OutputPin> _propertyPins;
+    private readonly ObjectOutputPins _objectOutputPins;
     private IDataModelEvent? _dataModelEvent;
 
     public EventConditionEventStartNode() : base(NodeId, "Event Arguments", "Contains the event arguments that triggered the evaluation")
     {
-        _propertyPins = new Dictionary<Func<DataModelEventArgs, object>, OutputPin>();
+        _objectOutputPins = new ObjectOutputPins(this);
     }
 
     public void CreatePins(IDataModelEvent? dataModelEvent)
@@ -25,30 +18,8 @@ internal class EventConditionEventStartNode : DefaultNode, IEventConditionNode
         if (_dataModelEvent == dataModelEvent)
             return;
 
-        while (Pins.Any())
-            RemovePin((Pin) Pins.First());
-        _propertyPins.Clear();
-
         _dataModelEvent = dataModelEvent;
-        if (dataModelEvent == null)
-            return;
-
-        foreach (PropertyInfo propertyInfo in dataModelEvent.ArgumentsType.GetProperties(BindingFlags.Instance | BindingFlags.Public)
-                     .Where(p => p.CustomAttributes.All(a => a.AttributeType != typeof(DataModelIgnoreAttribute))))
-        {
-            // Expect an IDataModelEvent
-            ParameterExpression eventParameter = Expression.Parameter(typeof(DataModelEventArgs), "event");
-            // Cast it to the actual event type
-            UnaryExpression eventCast = Expression.Convert(eventParameter, propertyInfo.DeclaringType!);
-            // Access the property
-            MemberExpression accessor = Expression.Property(eventCast, propertyInfo);
-            // Cast the property to an object (sadly boxing)
-            UnaryExpression objectCast = Expression.Convert(accessor, typeof(object));
-            // Compile the resulting expression
-            Func<DataModelEventArgs, object> expression = Expression.Lambda<Func<DataModelEventArgs, object>>(objectCast, eventParameter).Compile();
-
-            _propertyPins.Add(expression, CreateOrAddOutputPin(propertyInfo.PropertyType, propertyInfo.Name.Humanize()));
-        }
+        _objectOutputPins.ChangeType(dataModelEvent?.ArgumentsType);
     }
 
     public override void Evaluate()
@@ -56,12 +27,6 @@ internal class EventConditionEventStartNode : DefaultNode, IEventConditionNode
         if (_dataModelEvent?.LastEventArgumentsUntyped == null)
             return;
 
-        foreach ((Func<DataModelEventArgs, object> propertyAccessor, OutputPin outputPin) in _propertyPins)
-        {
-            if (!outputPin.ConnectedTo.Any())
-                continue;
-            object value = _dataModelEvent.LastEventArgumentsUntyped != null ? propertyAccessor(_dataModelEvent.LastEventArgumentsUntyped) : outputPin.Type.GetDefault()!;
-            outputPin.Value = outputPin.IsNumeric ? new Numeric(value) : value;
-        }
+        _objectOutputPins.SetCurrentValue(_dataModelEvent.LastEventArgumentsUntyped);
     }
 }

--- a/src/Artemis.Core/VisualScripting/Internal/EventConditionEventStartNode.cs
+++ b/src/Artemis.Core/VisualScripting/Internal/EventConditionEventStartNode.cs
@@ -2,7 +2,7 @@
 
 namespace Artemis.Core.Internal;
 
-internal class EventConditionEventStartNode : DefaultNode, IEventConditionNode
+internal class EventConditionEventStartNode : DefaultNode
 {
     internal static readonly Guid NodeId = new("278735FE-69E9-4A73-A6B8-59E83EE19305");
     private readonly ObjectOutputPins _objectOutputPins;
@@ -12,6 +12,11 @@ internal class EventConditionEventStartNode : DefaultNode, IEventConditionNode
     {
         _objectOutputPins = new ObjectOutputPins(this);
     }
+
+    public void SetDataModelEvent(IDataModelEvent? dataModelEvent)
+    {
+        
+    } 
 
     public void CreatePins(IDataModelEvent? dataModelEvent)
     {

--- a/src/Artemis.Core/VisualScripting/Internal/EventConditionValueChangedStartNode.cs
+++ b/src/Artemis.Core/VisualScripting/Internal/EventConditionValueChangedStartNode.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using Artemis.Core.VisualScripting.Internal;
 
 namespace Artemis.Core.Internal;
 

--- a/src/Artemis.Core/VisualScripting/Internal/EventConditionValueChangedStartNode.cs
+++ b/src/Artemis.Core/VisualScripting/Internal/EventConditionValueChangedStartNode.cs
@@ -2,7 +2,7 @@
 
 namespace Artemis.Core.Internal;
 
-internal class EventConditionValueChangedStartNode : DefaultNode, IEventConditionNode
+internal class EventConditionValueChangedStartNode : DefaultNode
 {
     internal static readonly Guid NodeId = new("F9A270DB-A231-4800-BAB3-DC1F96856756");
     private object? _newValue;

--- a/src/Artemis.Core/VisualScripting/Internal/IEventConditionNode.cs
+++ b/src/Artemis.Core/VisualScripting/Internal/IEventConditionNode.cs
@@ -1,4 +1,4 @@
-﻿namespace Artemis.Core.VisualScripting.Internal;
+﻿namespace Artemis.Core.Internal;
 
 internal interface IEventConditionNode : INode
 {

--- a/src/Artemis.Core/VisualScripting/Internal/IEventConditionNode.cs
+++ b/src/Artemis.Core/VisualScripting/Internal/IEventConditionNode.cs
@@ -1,5 +1,0 @@
-﻿namespace Artemis.Core.Internal;
-
-internal interface IEventConditionNode : INode
-{
-}

--- a/src/Artemis.Core/VisualScripting/Node.cs
+++ b/src/Artemis.Core/VisualScripting/Node.cs
@@ -132,7 +132,7 @@ public abstract class Node : BreakableModel, INode
     /// <param name="name">The name of the pin</param>
     /// <typeparam name="T">The type of value the pin will hold</typeparam>
     /// <returns>The newly created pin</returns>
-    protected InputPin<T> CreateInputPin<T>(string name = "")
+    public InputPin<T> CreateInputPin<T>(string name = "")
     {
         InputPin<T> pin = new(this, name);
         _pins.Add(pin);
@@ -146,7 +146,7 @@ public abstract class Node : BreakableModel, INode
     /// <param name="type">The type of value the pin will hold</param>
     /// <param name="name">The name of the pin</param>
     /// <returns>The newly created pin</returns>
-    protected InputPin CreateInputPin(Type type, string name = "")
+    public InputPin CreateInputPin(Type type, string name = "")
     {
         InputPin pin = new(this, type, name);
         _pins.Add(pin);
@@ -160,7 +160,7 @@ public abstract class Node : BreakableModel, INode
     /// <param name="name">The name of the pin</param>
     /// <typeparam name="T">The type of value the pin will hold</typeparam>
     /// <returns>The newly created pin</returns>
-    protected OutputPin<T> CreateOutputPin<T>(string name = "")
+    public OutputPin<T> CreateOutputPin<T>(string name = "")
     {
         OutputPin<T> pin = new(this, name);
         _pins.Add(pin);
@@ -174,7 +174,7 @@ public abstract class Node : BreakableModel, INode
     /// <param name="type">The type of value the pin will hold</param>
     /// <param name="name">The name of the pin</param>
     /// <returns>The newly created pin</returns>
-    protected OutputPin CreateOutputPin(Type type, string name = "")
+    public OutputPin CreateOutputPin(Type type, string name = "")
     {
         OutputPin pin = new(this, type, name);
         _pins.Add(pin);
@@ -187,7 +187,7 @@ public abstract class Node : BreakableModel, INode
     ///     The bucket might grow a bit over time as the user edits the node but pins won't get lost, enabling undo/redo in the
     ///     editor.
     /// </summary>
-    protected OutputPin CreateOrAddOutputPin(Type valueType, string displayName)
+    public OutputPin CreateOrAddOutputPin(Type valueType, string displayName)
     {
         // Grab the first pin from the bucket that isn't on the node yet
         OutputPin? pin = _outputPinBucket.FirstOrDefault(p => !Pins.Contains(p));
@@ -217,7 +217,7 @@ public abstract class Node : BreakableModel, INode
     ///     The bucket might grow a bit over time as the user edits the node but pins won't get lost, enabling undo/redo in the
     ///     editor.
     /// </summary>
-    protected InputPin CreateOrAddInputPin(Type valueType, string displayName)
+    public InputPin CreateOrAddInputPin(Type valueType, string displayName)
     {
         // Grab the first pin from the bucket that isn't on the node yet
         InputPin? pin = _inputPinBucket.FirstOrDefault(p => !Pins.Contains(p));
@@ -247,7 +247,7 @@ public abstract class Node : BreakableModel, INode
     /// </summary>
     /// <param name="pin">The pin to remove</param>
     /// <returns><see langword="true" /> if the pin was removed; otherwise <see langword="false" />.</returns>
-    protected bool RemovePin(Pin pin)
+    public bool RemovePin(Pin pin)
     {
         bool isRemoved = _pins.Remove(pin);
         if (isRemoved)
@@ -263,7 +263,7 @@ public abstract class Node : BreakableModel, INode
     ///     Adds an existing <paramref name="pin" /> to the <see cref="Pins" /> collection.
     /// </summary>
     /// <param name="pin">The pin to add</param>
-    protected void AddPin(Pin pin)
+    public void AddPin(Pin pin)
     {
         if (pin.Node != this)
             throw new ArtemisCoreException("Can't add a pin to a node that belongs to a different node than the one it's being added to.");
@@ -281,7 +281,7 @@ public abstract class Node : BreakableModel, INode
     /// <param name="name">The name of the pin collection</param>
     /// <param name="initialCount">The amount of pins to initially add to the collection</param>
     /// <returns>The resulting input pin collection</returns>
-    protected InputPinCollection<T> CreateInputPinCollection<T>(string name = "", int initialCount = 1)
+    public InputPinCollection<T> CreateInputPinCollection<T>(string name = "", int initialCount = 1)
     {
         InputPinCollection<T> pin = new(this, name, initialCount);
         _pinCollections.Add(pin);
@@ -296,7 +296,7 @@ public abstract class Node : BreakableModel, INode
     /// <param name="name">The name of the pin collection</param>
     /// <param name="initialCount">The amount of pins to initially add to the collection</param>
     /// <returns>The resulting input pin collection</returns>
-    protected InputPinCollection CreateInputPinCollection(Type type, string name = "", int initialCount = 1)
+    public InputPinCollection CreateInputPinCollection(Type type, string name = "", int initialCount = 1)
     {
         InputPinCollection pin = new(this, type, name, initialCount);
         _pinCollections.Add(pin);
@@ -311,7 +311,7 @@ public abstract class Node : BreakableModel, INode
     /// <param name="name">The name of the pin collection</param>
     /// <param name="initialCount">The amount of pins to initially add to the collection</param>
     /// <returns>The resulting output pin collection</returns>
-    protected OutputPinCollection<T> CreateOutputPinCollection<T>(string name = "", int initialCount = 1)
+    public OutputPinCollection<T> CreateOutputPinCollection<T>(string name = "", int initialCount = 1)
     {
         OutputPinCollection<T> pin = new(this, name, initialCount);
         _pinCollections.Add(pin);
@@ -325,7 +325,7 @@ public abstract class Node : BreakableModel, INode
     /// </summary>
     /// <param name="pinCollection">The pin collection to remove</param>
     /// <returns><see langword="true" /> if the pin collection was removed; otherwise <see langword="false" />.</returns>
-    protected bool RemovePinCollection(PinCollection pinCollection)
+    public bool RemovePinCollection(PinCollection pinCollection)
     {
         bool isRemoved = _pinCollections.Remove(pinCollection);
         if (isRemoved)

--- a/src/Artemis.Core/VisualScripting/Node.cs
+++ b/src/Artemis.Core/VisualScripting/Node.cs
@@ -339,7 +339,7 @@ public abstract class Node : BreakableModel, INode
     }
 
     /// <summary>
-    ///     Called when the node was loaded from storage or newly created
+    ///     Called when the node was loaded from storage or newly created, at this point pin connections aren't reestablished yet.
     /// </summary>
     /// <param name="script">The script the node is contained in</param>
     public virtual void Initialize(INodeScript script)

--- a/src/Artemis.Core/VisualScripting/NodeScript.cs
+++ b/src/Artemis.Core/VisualScripting/NodeScript.cs
@@ -80,7 +80,8 @@ public abstract class NodeScript : CorePropertyChanged, INodeScript
     ///     The context of the node script, usually a <see cref="Profile" /> or
     ///     <see cref="ProfileConfiguration" />
     /// </param>
-    protected NodeScript(string name, string description, object? context = null)
+    /// <param name="defaultNodes">A list of default nodes to add to the node script.</param>
+    protected NodeScript(string name, string description, object? context = null, List<DefaultNode>? defaultNodes = null)
     {
         Name = name;
         Description = description;
@@ -90,9 +91,15 @@ public abstract class NodeScript : CorePropertyChanged, INodeScript
 
         NodeTypeStore.NodeTypeAdded += NodeTypeStoreOnNodeTypeAdded;
         NodeTypeStore.NodeTypeRemoved += NodeTypeStoreOnNodeTypeRemoved;
+
+        if (defaultNodes != null)
+        {
+            foreach (DefaultNode defaultNode in defaultNodes)
+                AddNode(defaultNode);
+        }
     }
 
-    internal NodeScript(string name, string description, NodeScriptEntity entity, object? context = null)
+    internal NodeScript(string name, string description, NodeScriptEntity entity, object? context = null, List<DefaultNode>? defaultNodes = null)
     {
         Name = name;
         Description = description;
@@ -102,6 +109,12 @@ public abstract class NodeScript : CorePropertyChanged, INodeScript
 
         NodeTypeStore.NodeTypeAdded += NodeTypeStoreOnNodeTypeAdded;
         NodeTypeStore.NodeTypeRemoved += NodeTypeStoreOnNodeTypeRemoved;
+        
+        if (defaultNodes != null)
+        {
+            foreach (DefaultNode defaultNode in defaultNodes)
+                AddNode(defaultNode);
+        }
     }
 
     #endregion
@@ -414,8 +427,8 @@ public class NodeScript<T> : NodeScript, INodeScript<T>
     #region Constructors
 
     /// <inheritdoc />
-    public NodeScript(string name, string description, NodeScriptEntity entity, object? context = null)
-        : base(name, description, entity, context)
+    public NodeScript(string name, string description, NodeScriptEntity entity, object? context = null, List<DefaultNode>? defaultNodes = null)
+        : base(name, description, entity, context, defaultNodes)
     {
         ExitNode = new ExitNode<T>(name, description);
         AddNode(ExitNode);
@@ -424,8 +437,8 @@ public class NodeScript<T> : NodeScript, INodeScript<T>
     }
 
     /// <inheritdoc />
-    public NodeScript(string name, string description, object? context = null)
-        : base(name, description, context)
+    public NodeScript(string name, string description, object? context = null, List<DefaultNode>? defaultNodes = null)
+        : base(name, description, context, defaultNodes)
     {
         ExitNode = new ExitNode<T>(name, description);
         AddNode(ExitNode);

--- a/src/Artemis.Core/VisualScripting/NodeScript.cs
+++ b/src/Artemis.Core/VisualScripting/NodeScript.cs
@@ -35,7 +35,10 @@ public abstract class NodeScript : CorePropertyChanged, INodeScript
 
     #region Properties & Fields
 
-    internal NodeScriptEntity Entity { get; private set; }
+    /// <summary>
+    ///     Gets the entity used to store this script.
+    /// </summary>
+    public NodeScriptEntity Entity { get; private set; }
 
     /// <inheritdoc />
     public string Name { get; }
@@ -410,7 +413,8 @@ public class NodeScript<T> : NodeScript, INodeScript<T>
 
     #region Constructors
 
-    internal NodeScript(string name, string description, NodeScriptEntity entity, object? context = null)
+    /// <inheritdoc />
+    public NodeScript(string name, string description, NodeScriptEntity entity, object? context = null)
         : base(name, description, entity, context)
     {
         ExitNode = new ExitNode<T>(name, description);

--- a/src/Artemis.Core/VisualScripting/ObjectOutputPins.cs
+++ b/src/Artemis.Core/VisualScripting/ObjectOutputPins.cs
@@ -1,0 +1,142 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using Artemis.Core.Modules;
+using Humanizer;
+
+namespace Artemis.Core;
+
+/// <summary>
+///     Represents a collection of output pins for a node capable of outputting the properties of an object or value type.
+/// </summary>
+public class ObjectOutputPins
+{
+    private readonly Dictionary<Func<object, object>, OutputPin> _propertyPins;
+    private OutputPin? _valueTypePin;
+
+    /// <summary>
+    ///     Creates an instance of the <see cref="ObjectOutputPins" /> class.
+    /// </summary>
+    /// <param name="node">The node the object output was created for.</param>
+    public ObjectOutputPins(Node node)
+    {
+        Node = node;
+        _propertyPins = new Dictionary<Func<object, object>, OutputPin>();
+    }
+
+    /// <summary>
+    ///     Gets the node the object output was created for.
+    /// </summary>
+    public Node Node { get; }
+
+    /// <summary>
+    ///     Gets the current type the node's pins are set up for.
+    /// </summary>
+    public Type? CurrentType { get; private set; }
+
+    /// <summary>
+    ///     Gets a read only collection of the pins outputting the object of this object node.
+    /// </summary>
+    public ReadOnlyCollection<OutputPin> Pins => _valueTypePin != null ? new ReadOnlyCollection<OutputPin>(new List<OutputPin> {_valueTypePin}) : _propertyPins.Values.ToList().AsReadOnly();
+
+    /// <summary>
+    ///     Change the current type and create pins on the node to reflect this.
+    /// </summary>
+    /// <param name="type">The type to change the collection to.</param>
+    public void ChangeType(Type? type)
+    {
+        if (type == CurrentType)
+            return;
+        CurrentType = type;
+
+        // Remove current pins
+        foreach ((Func<object, object>? _, OutputPin? pin) in _propertyPins)
+            Node.RemovePin(pin);
+        _propertyPins.Clear();
+        if (_valueTypePin != null)
+        {
+            Node.RemovePin(_valueTypePin);
+            _valueTypePin = null;
+        }
+
+        if (type == null)
+            return;
+
+        // Create new pins
+        List<TypeColorRegistration> nodeTypeColors = NodeTypeStore.GetColors();
+        if (type.IsClass && type != typeof(string))
+            foreach (PropertyInfo propertyInfo in type.GetProperties(BindingFlags.Instance | BindingFlags.Public))
+            {
+                Type propertyType = propertyInfo.PropertyType;
+                bool toNumeric = Numeric.IsTypeCompatible(propertyType);
+
+                // Skip ignored properties
+                if (propertyInfo.CustomAttributes.Any(a => a.AttributeType == typeof(DataModelIgnoreAttribute)))
+                    continue;
+                // Skip incompatible properties
+                if (!toNumeric && !nodeTypeColors.Any(c => c.Type.IsAssignableFrom(propertyType)))
+                    continue;
+
+                // Expect an object
+                ParameterExpression itemParameter = Expression.Parameter(typeof(object), "item");
+                // Cast it to the actual item type
+                UnaryExpression itemCast = Expression.Convert(itemParameter, propertyInfo.DeclaringType!);
+                // Access the property
+                MemberExpression accessor = Expression.Property(itemCast, propertyInfo);
+
+                // Turn into a numeric if needed or access directly
+                UnaryExpression objectExpression;
+                if (toNumeric)
+                {
+                    propertyType = typeof(Numeric);
+                    ConstructorInfo constructor = typeof(Numeric).GetConstructors().First(c => c.GetParameters().First().ParameterType == propertyInfo.PropertyType);
+                    // Cast the property to an object (sadly boxing)
+                    objectExpression = Expression.Convert(Expression.New(constructor, accessor), typeof(object));
+                }
+                else
+                {
+                    // Cast the property to an object (sadly boxing)
+                    objectExpression = Expression.Convert(accessor, typeof(object));
+                }
+
+                // Compile the resulting expression
+                Func<object, object> expression = Expression.Lambda<Func<object, object>>(objectExpression, itemParameter).Compile();
+                _propertyPins.Add(expression, Node.CreateOrAddOutputPin(propertyType, propertyInfo.Name.Humanize()));
+            }
+        else
+            // Value types are applied directly to a single pin, however if the type is compatible with Numeric, we use a Numeric pin instead
+            // the value will then be turned into a numeric in SetCurrentValue
+            _valueTypePin = Node.CreateOrAddOutputPin(Numeric.IsTypeCompatible(type) ? typeof(Numeric) : type, "Item");
+    }
+
+    /// <summary>
+    ///     Set the current value to be output onto connected pins.
+    /// </summary>
+    /// <param name="value">The value to output onto the connected pins.</param>
+    /// <exception cref="ArtemisCoreException"></exception>
+    public void SetCurrentValue(object? value)
+    {
+        if (CurrentType == null)
+            throw new ArtemisCoreException("Cannot apply a value to an object output pins not yet configured for a type.");
+        if (value != null && CurrentType != value.GetType())
+            throw new ArtemisCoreException($"Cannot apply a value of type {value.GetType().FullName} to an object output pins configured for type {CurrentType.FullName}");
+
+        // Apply the object to the pin, it must be connected if SetCurrentValue got called
+        if (_valueTypePin != null)
+        {
+            value ??= _valueTypePin.Type.GetDefault();
+            _valueTypePin.Value = _valueTypePin.Type == typeof(Numeric) ? new Numeric(value) : value;
+            return;
+        }
+
+        // Apply the properties of the object to each connected pin
+        foreach ((Func<object, object>? propertyAccessor, OutputPin? outputPin) in _propertyPins)
+        {
+            if (outputPin.ConnectedTo.Any())
+                outputPin.Value = value != null ? propertyAccessor(value) : outputPin.Type.GetDefault();
+        }
+    }
+}

--- a/src/Artemis.UI.Shared/Services/NodeEditor/NodeScriptWindowViewModelBase.cs
+++ b/src/Artemis.UI.Shared/Services/NodeEditor/NodeScriptWindowViewModelBase.cs
@@ -1,0 +1,23 @@
+using Artemis.Core;
+
+namespace Artemis.UI.Shared.Services.NodeEditor;
+
+/// <summary>
+///     Represents the base of the node script editor window view model.
+/// </summary>
+public abstract class NodeScriptWindowViewModelBase : DialogViewModelBase<bool>
+{
+    /// <summary>
+    ///     Creates a new instance of the <see cref="NodeScriptWindowViewModelBase" /> class.
+    /// </summary>
+    /// <param name="nodeScript">The node script being edited.</param>
+    protected NodeScriptWindowViewModelBase(NodeScript nodeScript)
+    {
+        NodeScript = nodeScript;
+    }
+
+    /// <summary>
+    ///     Gets the node script being edited.
+    /// </summary>
+    public NodeScript NodeScript { get; init; }
+}

--- a/src/Artemis.UI.Shared/Services/ProfileEditor/Commands/UpdateEventConditionPath.cs
+++ b/src/Artemis.UI.Shared/Services/ProfileEditor/Commands/UpdateEventConditionPath.cs
@@ -49,7 +49,7 @@ public class UpdateEventConditionPath : IProfileEditorCommand, IDisposable
 
         // Change the end node 
         _eventCondition.EventPath = _value;
-        _eventCondition.UpdateEventNode();
+        _eventCondition.UpdateEventNode(true);
 
         _executed = true;
     }
@@ -59,7 +59,7 @@ public class UpdateEventConditionPath : IProfileEditorCommand, IDisposable
     {
         // Change the end node
         _eventCondition.EventPath = _oldValue;
-        _eventCondition.UpdateEventNode();
+        _eventCondition.UpdateEventNode(true);
 
         // Restore old connections
         _store?.Restore();

--- a/src/Artemis.UI.Shared/Styles/Condensed.axaml
+++ b/src/Artemis.UI.Shared/Styles/Condensed.axaml
@@ -103,4 +103,11 @@
 		<Setter Property="Padding" Value="6 3 11 3" />
 		<Setter Property="Height" Value="24" />
     </Style>
+    
+    <Style Selector="Button.condensed">
+        <Setter Property="Padding" Value="1" />
+        <Setter Property="FontSize" Value="13" />
+        <Setter Property="MinHeight" Value="24" />
+    </Style>
+
 </Styles>

--- a/src/Artemis.UI.Windows/Providers/Input/WindowsInputProvider.cs
+++ b/src/Artemis.UI.Windows/Providers/Input/WindowsInputProvider.cs
@@ -19,7 +19,6 @@ public class WindowsInputProvider : InputProvider
     private readonly ILogger _logger;
     private readonly SpongeWindow _sponge;
     private readonly Timer _taskManagerTimer;
-    private DateTime _lastMouseUpdate;
     private int _lastProcessId;
 
     public WindowsInputProvider(ILogger logger, IInputService inputService)
@@ -160,8 +159,8 @@ public class WindowsInputProvider : InputProvider
 
     #region Mouse
 
-    private int _mouseDeltaX;
-    private int _mouseDeltaY;
+    private int _previousMouseX;
+    private int _previousMouseY;
 
     private void HandleMouseData(RawInputData data, RawInputMouseData mouseData)
     {
@@ -169,10 +168,8 @@ public class WindowsInputProvider : InputProvider
         // This can create a small inaccuracy of course, but Artemis is not a shooter :')
         if (mouseData.Mouse.Buttons == RawMouseButtonFlags.None)
         {
-            _mouseDeltaX += mouseData.Mouse.LastX;
-            _mouseDeltaY += mouseData.Mouse.LastY;
-            if (DateTime.Now - _lastMouseUpdate < TimeSpan.FromMilliseconds(40))
-                return;
+            _previousMouseX += mouseData.Mouse.LastX;
+            _previousMouseY += mouseData.Mouse.LastY;
         }
 
         ArtemisDevice? device = null;
@@ -193,10 +190,7 @@ public class WindowsInputProvider : InputProvider
         if (mouseData.Mouse.Buttons == RawMouseButtonFlags.None)
         {
             Win32Point cursorPosition = GetCursorPosition();
-            OnMouseMoveDataReceived(device, cursorPosition.X, cursorPosition.Y, _mouseDeltaX, _mouseDeltaY);
-            _mouseDeltaX = 0;
-            _mouseDeltaY = 0;
-            _lastMouseUpdate = DateTime.Now;
+            OnMouseMoveDataReceived(device, cursorPosition.X, cursorPosition.Y, cursorPosition.X - _previousMouseX, cursorPosition.Y - _previousMouseY);
             return;
         }
 

--- a/src/Artemis.UI/Ninject/UiModule.cs
+++ b/src/Artemis.UI/Ninject/UiModule.cs
@@ -2,8 +2,10 @@
 using Artemis.UI.Ninject.Factories;
 using Artemis.UI.Ninject.InstanceProviders;
 using Artemis.UI.Screens;
+using Artemis.UI.Screens.VisualScripting;
 using Artemis.UI.Services.Interfaces;
 using Artemis.UI.Shared;
+using Artemis.UI.Shared.Services.NodeEditor;
 using Artemis.UI.Shared.Services.ProfileEditor;
 using Avalonia.Platform;
 using Avalonia.Shared.PlatformSupport;
@@ -57,6 +59,7 @@ public class UIModule : NinjectModule
                 .BindToFactory();
         });
 
+        Kernel.Bind<NodeScriptWindowViewModelBase>().To<NodeScriptWindowViewModel>();
         Kernel.Bind<IPropertyVmFactory>().ToFactory(() => new LayerPropertyViewModelInstanceProvider());
 
         // Bind all UI services as singletons

--- a/src/Artemis.UI/Screens/ProfileEditor/Panels/Properties/PropertiesViewModel.cs
+++ b/src/Artemis.UI/Screens/ProfileEditor/Panels/Properties/PropertiesViewModel.cs
@@ -76,18 +76,23 @@ public class PropertiesViewModel : ActivatableViewModelBase
         });
 
         // Subscribe to events of the latest selected profile element - borrowed from https://stackoverflow.com/a/63950940
-        this.WhenAnyValue(vm => vm.ProfileElement)
-            .Select(p => p is Layer l
-                ? Observable.FromEventPattern(x => l.LayerBrushUpdated += x, x => l.LayerBrushUpdated -= x)
-                : Observable.Never<EventPattern<object>>())
-            .Switch()
-            .Subscribe(_ => UpdatePropertyGroups());
-        this.WhenAnyValue(vm => vm.ProfileElement)
-            .Select(p => p != null
-                ? Observable.FromEventPattern(x => p.LayerEffectsUpdated += x, x => p.LayerEffectsUpdated -= x)
-                : Observable.Never<EventPattern<object>>())
-            .Switch()
-            .Subscribe(_ => UpdatePropertyGroups());
+        this.WhenActivated(d =>
+        {
+            this.WhenAnyValue(vm => vm.ProfileElement)
+                .Select(p => p is Layer l
+                    ? Observable.FromEventPattern(x => l.LayerBrushUpdated += x, x => l.LayerBrushUpdated -= x)
+                    : Observable.Never<EventPattern<object>>())
+                .Switch()
+                .Subscribe(_ => UpdatePropertyGroups())
+                .DisposeWith(d);
+            this.WhenAnyValue(vm => vm.ProfileElement)
+                .Select(p => p != null
+                    ? Observable.FromEventPattern(x => p.LayerEffectsUpdated += x, x => p.LayerEffectsUpdated -= x)
+                    : Observable.Never<EventPattern<object>>())
+                .Switch()
+                .Subscribe(_ => UpdatePropertyGroups())
+                .DisposeWith(d);
+        });
         this.WhenAnyValue(vm => vm.ProfileElement).Subscribe(_ => UpdatePropertyGroups());
         this.WhenAnyValue(vm => vm.LayerProperty).Subscribe(_ => UpdateTimelineViewModel());
     }

--- a/src/Artemis.UI/Screens/VisualScripting/NodeScriptWindowViewModel.cs
+++ b/src/Artemis.UI/Screens/VisualScripting/NodeScriptWindowViewModel.cs
@@ -8,7 +8,6 @@ using System.Threading.Tasks;
 using Artemis.Core;
 using Artemis.Core.Services;
 using Artemis.UI.Ninject.Factories;
-using Artemis.UI.Shared;
 using Artemis.UI.Shared.Services;
 using Artemis.UI.Shared.Services.NodeEditor;
 using Artemis.UI.Shared.Services.NodeEditor.Commands;
@@ -20,7 +19,7 @@ using ReactiveUI;
 
 namespace Artemis.UI.Screens.VisualScripting;
 
-public class NodeScriptWindowViewModel : DialogViewModelBase<bool>
+public class NodeScriptWindowViewModel : NodeScriptWindowViewModelBase
 {
     private readonly INodeEditorService _nodeEditorService;
     private readonly INodeService _nodeService;
@@ -34,7 +33,7 @@ public class NodeScriptWindowViewModel : DialogViewModelBase<bool>
         INodeVmFactory vmFactory,
         ISettingsService settingsService,
         IProfileService profileService,
-        IWindowService windowService)
+        IWindowService windowService) : base(nodeScript)
     {
         NodeScript = nodeScript;
         NodeScriptViewModel = vmFactory.NodeScriptViewModel(NodeScript, false);
@@ -77,7 +76,6 @@ public class NodeScriptWindowViewModel : DialogViewModelBase<bool>
         });
     }
 
-    public NodeScript NodeScript { get; }
     public NodeScriptViewModel NodeScriptViewModel { get; set; }
 
     public NodeEditorHistory History { get; }

--- a/src/Artemis.VisualScripting/Nodes/DataModel/DataModelEventNode.cs
+++ b/src/Artemis.VisualScripting/Nodes/DataModel/DataModelEventNode.cs
@@ -1,29 +1,25 @@
-﻿using System.Linq.Expressions;
-using System.Reflection;
-using Artemis.Core;
-using Artemis.Core.Modules;
+﻿using Artemis.Core;
 using Artemis.Storage.Entities.Profile;
 using Artemis.VisualScripting.Nodes.DataModel.Screens;
-using Humanizer;
 
 namespace Artemis.VisualScripting.Nodes.DataModel;
 
 [Node("Data Model-Event", "Outputs the latest values of a data model event.", "Data Model", OutputType = typeof(object))]
 public class DataModelEventNode : Node<DataModelPathEntity, DataModelEventNodeCustomViewModel>, IDisposable
 {
-    private readonly Dictionary<Func<DataModelEventArgs, object>, OutputPin> _propertyPins;
-    private DataModelPath? _dataModelPath;
+    private readonly ObjectOutputPins _objectOutputPins;
     private IDataModelEvent? _dataModelEvent;
-    private OutputPin? _oldValuePin;
-    private OutputPin? _newValuePin;
+    private DataModelPath? _dataModelPath;
     private DateTime _lastTrigger;
     private object? _lastValue;
+    private OutputPin? _newValuePin;
+    private OutputPin? _oldValuePin;
     private int _valueChangeCount;
 
     public DataModelEventNode() : base("Data Model-Event", "Outputs the latest values of a data model event.")
     {
-        _propertyPins = new Dictionary<Func<DataModelEventArgs, object>, OutputPin>();
-        
+        _objectOutputPins = new ObjectOutputPins(this);
+
         TimeSinceLastTrigger = CreateOutputPin<Numeric>("Time since trigger");
         TriggerCount = CreateOutputPin<Numeric>("Trigger count");
 
@@ -48,20 +44,14 @@ public class DataModelEventNode : Node<DataModelPathEntity, DataModelEventNodeCu
     public override void Evaluate()
     {
         object? pathValue = _dataModelPath?.GetValue();
-        
+
         // If the path is a data model event, evaluate the event
         if (pathValue is IDataModelEvent dataModelEvent)
         {
             TimeSinceLastTrigger.Value = dataModelEvent.TimeSinceLastTrigger.TotalMilliseconds;
             TriggerCount.Value = dataModelEvent.TriggerCount;
 
-            foreach ((Func<DataModelEventArgs, object> propertyAccessor, OutputPin outputPin) in _propertyPins)
-            {
-                if (!outputPin.ConnectedTo.Any())
-                    continue;
-                object value = dataModelEvent.LastEventArgumentsUntyped != null ? propertyAccessor(dataModelEvent.LastEventArgumentsUntyped) : outputPin.Type.GetDefault()!;
-                outputPin.Value = outputPin.IsNumeric ? new Numeric(value) : value;
-            }
+            _objectOutputPins.SetCurrentValue(dataModelEvent.LastEventArgumentsUntyped);
         }
         // If the path is a regular value, evaluate the current value
         else if (_oldValuePin != null && _newValuePin != null)
@@ -71,13 +61,13 @@ public class DataModelEventNode : Node<DataModelPathEntity, DataModelEventNodeCu
                 TimeSinceLastTrigger.Value = (DateTime.Now - _lastTrigger).TotalMilliseconds;
                 return;
             }
-           
+
             _valueChangeCount++;
             _lastTrigger = DateTime.Now;
-            
+
             _oldValuePin.Value = _lastValue;
             _newValuePin.Value = pathValue;
-            
+
             _lastValue = pathValue;
 
             TimeSinceLastTrigger.Value = 0;
@@ -91,19 +81,20 @@ public class DataModelEventNode : Node<DataModelPathEntity, DataModelEventNodeCu
         _dataModelPath = Storage != null ? new DataModelPath(Storage) : null;
         if (_dataModelPath != null)
             _dataModelPath.PathValidated += DataModelPathOnPathValidated;
-        
+
         if (old != null)
         {
             old.PathValidated -= DataModelPathOnPathValidated;
             old.Dispose();
         }
-        
+
         UpdateOutputPins();
     }
 
     private void UpdateOutputPins()
     {
         object? pathValue = _dataModelPath?.GetValue();
+
         if (pathValue is IDataModelEvent dataModelEvent)
             CreateEventPins(dataModelEvent);
         else
@@ -114,25 +105,10 @@ public class DataModelEventNode : Node<DataModelPathEntity, DataModelEventNodeCu
     {
         if (_dataModelEvent == dataModelEvent)
             return;
-        
+
         ClearPins();
         _dataModelEvent = dataModelEvent;
-        foreach (PropertyInfo propertyInfo in dataModelEvent.ArgumentsType.GetProperties(BindingFlags.Instance | BindingFlags.Public)
-                     .Where(p => p.CustomAttributes.All(a => a.AttributeType != typeof(DataModelIgnoreAttribute))))
-        {
-            // Expect an IDataModelEvent
-            ParameterExpression eventParameter = Expression.Parameter(typeof(DataModelEventArgs), "event");
-            // Cast it to the actual event type
-            UnaryExpression eventCast = Expression.Convert(eventParameter, propertyInfo.DeclaringType!);
-            // Access the property
-            MemberExpression accessor = Expression.Property(eventCast, propertyInfo);
-            // Cast the property to an object (sadly boxing)
-            UnaryExpression objectCast = Expression.Convert(accessor, typeof(object));
-            // Compile the resulting expression
-            Func<DataModelEventArgs, object> expression = Expression.Lambda<Func<DataModelEventArgs, object>>(objectCast, eventParameter).Compile();
-
-            _propertyPins.Add(expression, CreateOrAddOutputPin(propertyInfo.PropertyType, propertyInfo.Name.Humanize()));
-        }
+        _objectOutputPins.ChangeType(dataModelEvent.ArgumentsType);
     }
 
     private void CreateValuePins()
@@ -142,24 +118,31 @@ public class DataModelEventNode : Node<DataModelPathEntity, DataModelEventNodeCu
         Type? propertyType = _dataModelPath?.GetPropertyType();
         if (propertyType == null)
             return;
-        
+
         _oldValuePin = CreateOrAddOutputPin(propertyType, "Old value");
         _newValuePin = CreateOrAddOutputPin(propertyType, "New value");
         _lastValue = null;
         _valueChangeCount = 0;
     }
-    
+
     private void ClearPins()
     {
-        List<IPin> pins = Pins.Skip(2).ToList();
-        foreach (IPin pin in pins)
-            RemovePin((Pin) pin);
-        
-        _propertyPins.Clear();
-        _oldValuePin = null;
-        _newValuePin = null;
+        // Clear the output pins by changing the type to null
+        _objectOutputPins.ChangeType(null);
+
+        if (_oldValuePin != null)
+        {
+            RemovePin(_oldValuePin);
+            _oldValuePin = null;
+        }
+
+        if (_newValuePin != null)
+        {
+            RemovePin(_newValuePin);
+            _newValuePin = null;
+        }
     }
-    
+
     private void DataModelPathOnPathValidated(object? sender, EventArgs e)
     {
         // Update the output pin now that the type is known and attempt to restore the connection that was likely missing

--- a/src/Artemis.VisualScripting/Nodes/List/ListOperatorEntity.cs
+++ b/src/Artemis.VisualScripting/Nodes/List/ListOperatorEntity.cs
@@ -1,0 +1,9 @@
+using Artemis.Storage.Entities.Profile.Nodes;
+
+namespace Artemis.VisualScripting.Nodes.List;
+
+public class ListOperatorEntity
+{
+    public NodeScriptEntity? Script { get; set; }
+    public ListOperator Operator { get; set; }
+}

--- a/src/Artemis.VisualScripting/Nodes/List/ListOperatorNode.cs
+++ b/src/Artemis.VisualScripting/Nodes/List/ListOperatorNode.cs
@@ -4,37 +4,37 @@ using Artemis.VisualScripting.Nodes.List.Screens;
 
 namespace Artemis.VisualScripting.Nodes.List;
 
-[Node("List Operator (Simple)", "Checks if any/all/no value in the input list matches the input value", "List", InputType = typeof(IEnumerable), OutputType = typeof(bool))]
+[Node("List Operator (Simple)", "Checks if any/all/no values in the input list match the input value", "List", InputType = typeof(IEnumerable), OutputType = typeof(bool))]
 public class ListOperatorNode : Node<ListOperator, ListOperatorNodeCustomViewModel>
 {
-    public ListOperatorNode() : base("List Operator", "Checks if any/all/no value in the input list matches the input value")
+    public ListOperatorNode() : base("List Operator (Simple)", "Checks if any/all/no values in the input list match the input value")
     {
         InputList = CreateInputPin<IList>();
         InputValue = CreateInputPin<object>();
 
-        Ouput = CreateOutputPin<bool>();
+        Output = CreateOutputPin<bool>();
     }
 
     public InputPin<IList> InputList { get; }
     public InputPin<object> InputValue { get; }
-    public OutputPin<bool> Ouput { get; }
+    public OutputPin<bool> Output { get; }
     
     /// <inheritdoc />
     public override void Evaluate()
     {
         if (InputList.Value == null)
         {
-            Ouput.Value = Storage == ListOperator.None;
+            Output.Value = Storage == ListOperator.None;
             return;
         }
 
         object? input = InputValue.Value;
         if (Storage == ListOperator.Any)
-            Ouput.Value = InputList.Value.Cast<object>().Any(v => v.Equals(input));
+            Output.Value = InputList.Value.Cast<object>().Any(v => v.Equals(input));
         else if (Storage == ListOperator.All)
-            Ouput.Value = InputList.Value.Cast<object>().All(v => v.Equals(input));
-        else if (Storage == ListOperator.All)
-            Ouput.Value = InputList.Value.Cast<object>().All(v => !v.Equals(input));
+            Output.Value = InputList.Value.Cast<object>().All(v => v.Equals(input));
+        else if (Storage == ListOperator.None)
+            Output.Value = InputList.Value.Cast<object>().All(v => !v.Equals(input));
     }
 }
 

--- a/src/Artemis.VisualScripting/Nodes/List/ListOperatorPredicateNode.cs
+++ b/src/Artemis.VisualScripting/Nodes/List/ListOperatorPredicateNode.cs
@@ -1,0 +1,118 @@
+using System.Collections;
+using Artemis.Core;
+using Artemis.Core.Events;
+using Artemis.VisualScripting.Nodes.List.Screens;
+
+namespace Artemis.VisualScripting.Nodes.List;
+
+[Node("List Operator (Advanced)", "Checks if any/all/no values in the input list match a condition", "List", InputType = typeof(IEnumerable), OutputType = typeof(bool))]
+public class ListOperatorPredicateNode : Node<ListOperatorEntity, ListOperatorPredicateNodeCustomViewModel>, IDisposable
+{
+    private readonly object _scriptLock = new();
+    private ListOperatorPredicateStartNode? _startNode;
+
+    public ListOperatorPredicateNode() : base("List Operator (Advanced)", "Checks if any/all/no values in the input list match a condition")
+    {
+
+        InputList = CreateInputPin<IList>();
+        Output = CreateOutputPin<bool>();
+
+        InputList.PinConnected += InputListOnPinConnected;
+    }
+
+    public InputPin<IList> InputList { get; }
+    public OutputPin<bool> Output { get; }
+    public NodeScript<bool>? Script { get; private set; }
+
+    public override void Initialize(INodeScript script)
+    {
+        Storage ??= new ListOperatorEntity();
+
+        lock (_scriptLock)
+        {
+            Script = Storage?.Script != null
+                ? new NodeScript<bool>("Is match", "Determines whether the current list item is a match", Storage.Script, script.Context)
+                : new NodeScript<bool>("Is match", "Determines whether the current list item is a match", script.Context);
+
+            // The load action may have created an event node, use that one over the one we have here
+            INode? existingEventNode = Script.Nodes.FirstOrDefault(n => n.Id == ListOperatorPredicateStartNode.NodeId);
+            if (existingEventNode != null)
+                _startNode = (ListOperatorPredicateStartNode) existingEventNode;
+            else
+            {
+                _startNode = new ListOperatorPredicateStartNode {X = -200};
+                Script.AddNode(_startNode);
+            }
+
+            UpdateStartNode();
+            Script.LoadConnections();
+        }
+    }
+
+    /// <inheritdoc />
+    public override void Evaluate()
+    {
+        if (Storage == null)
+            return;
+
+        if (InputList.Value == null)
+        {
+            Output.Value = Storage.Operator == ListOperator.None;
+            return;
+        }
+
+        lock (_scriptLock)
+        {
+            if (Script == null)
+                return;
+
+            if (Storage.Operator == ListOperator.Any)
+                Output.Value = InputList.Value.Cast<object>().Any(EvaluateItem);
+            else if (Storage.Operator == ListOperator.All)
+                Output.Value = InputList.Value.Cast<object>().All(EvaluateItem);
+            else if (Storage.Operator == ListOperator.None)
+                Output.Value = InputList.Value.Cast<object>().All(v => !EvaluateItem(v));
+        }
+    }
+
+    private bool EvaluateItem(object item)
+    {
+        if (Script == null || _startNode == null)
+            return false;
+
+        _startNode.Item = item;
+        Script.Run();
+        return Script.Result;
+    }
+
+    private void UpdateStartNode()
+    {
+        Type? type = InputList.ConnectedTo.FirstOrDefault()?.Type;
+        // List must be generic or there's no way to tell what objects it contains in advance, that's not supported for now
+        if (type is not {IsGenericType: true})
+            return;
+
+        Type listType = type.GetGenericArguments().Single();
+        _startNode?.ChangeType(listType);
+    }
+
+    private void InputListOnPinConnected(object? sender, SingleValueEventArgs<IPin> e)
+    {
+        lock (_scriptLock)
+        {
+            UpdateStartNode();
+        }
+    }
+
+    #region IDisposable
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        Script?.Dispose();
+        Script = null;
+        _startNode = null;
+    }
+
+    #endregion
+}

--- a/src/Artemis.VisualScripting/Nodes/List/ListOperatorPredicateStartNode.cs
+++ b/src/Artemis.VisualScripting/Nodes/List/ListOperatorPredicateStartNode.cs
@@ -1,0 +1,27 @@
+using Artemis.Core;
+
+namespace Artemis.VisualScripting.Nodes.List;
+
+public class ListOperatorPredicateStartNode : DefaultNode
+{
+    internal static readonly Guid NodeId = new("9A714CF3-8D02-4CC3-A1AC-73833F82D7C6");
+    private readonly ObjectOutputPins _objectOutputPins;
+
+    public ListOperatorPredicateStartNode() : base(NodeId, "List item", "Contains the current list item")
+    {
+        _objectOutputPins = new ObjectOutputPins(this);
+    }
+
+    public object? Item { get; set; }
+
+    public override void Evaluate()
+    {
+        if (Item != null)
+            _objectOutputPins.SetCurrentValue(Item);
+    }
+
+    public void ChangeType(Type? type)
+    {
+        _objectOutputPins.ChangeType(type);
+    }
+}

--- a/src/Artemis.VisualScripting/Nodes/List/Screens/ListOperatorPredicateNodeCustomView.axaml
+++ b/src/Artemis.VisualScripting/Nodes/List/Screens/ListOperatorPredicateNodeCustomView.axaml
@@ -1,0 +1,14 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:screens="clr-namespace:Artemis.VisualScripting.Nodes.List.Screens"
+             xmlns:shared="clr-namespace:Artemis.UI.Shared;assembly=Artemis.UI.Shared"
+             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+             x:Class="Artemis.VisualScripting.Nodes.List.Screens.ListOperatorPredicateNodeCustomView"
+             x:DataType="screens:ListOperatorPredicateNodeCustomViewModel">
+<StackPanel Spacing="5">
+    <shared:EnumComboBox Value="{CompiledBinding Operator}" Classes="condensed" HorizontalAlignment="Stretch"/>
+    <Button HorizontalAlignment="Stretch" Classes="condensed" Command="{CompiledBinding OpenEditor}">Edit script</Button>
+</StackPanel>
+</UserControl>

--- a/src/Artemis.VisualScripting/Nodes/List/Screens/ListOperatorPredicateNodeCustomView.axaml.cs
+++ b/src/Artemis.VisualScripting/Nodes/List/Screens/ListOperatorPredicateNodeCustomView.axaml.cs
@@ -1,0 +1,19 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+using Avalonia.ReactiveUI;
+
+namespace Artemis.VisualScripting.Nodes.List.Screens;
+
+public partial class ListOperatorPredicateNodeCustomView : ReactiveUserControl<ListOperatorPredicateNodeCustomViewModel>
+{
+    public ListOperatorPredicateNodeCustomView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/src/Artemis.VisualScripting/Nodes/List/Screens/ListOperatorPredicateNodeCustomViewModel.cs
+++ b/src/Artemis.VisualScripting/Nodes/List/Screens/ListOperatorPredicateNodeCustomViewModel.cs
@@ -1,0 +1,43 @@
+using System.Reactive;
+using Artemis.Core;
+using Artemis.UI.Shared.Services;
+using Artemis.UI.Shared.Services.NodeEditor;
+using Artemis.UI.Shared.VisualScripting;
+using ReactiveUI;
+
+namespace Artemis.VisualScripting.Nodes.List.Screens;
+
+public class ListOperatorPredicateNodeCustomViewModel : CustomNodeViewModel
+{
+    private readonly ListOperatorPredicateNode _node;
+    private readonly IWindowService _windowService;
+    private ListOperator _operator;
+
+    public ListOperatorPredicateNodeCustomViewModel(ListOperatorPredicateNode node, INodeScript script, IWindowService windowService) : base(node, script)
+    {
+        _node = node;
+        _windowService = windowService;
+
+        OpenEditor = ReactiveCommand.CreateFromTask(ExecuteOpenEditor);
+    }
+
+    public ReactiveCommand<Unit, Unit> OpenEditor { get; }
+
+    public ListOperator Operator
+    {
+        get => _operator;
+        set => this.RaiseAndSetIfChanged(ref _operator, value);
+    }
+
+    private async Task ExecuteOpenEditor()
+    {
+        if (_node.Script == null)
+            return;
+
+        await _windowService.ShowDialogAsync<NodeScriptWindowViewModelBase, bool>(("nodeScript", _node.Script));
+        _node.Script.Save();
+
+        _node.Storage ??= new ListOperatorEntity();
+        _node.Storage.Script = _node.Script.Entity;
+    }
+}


### PR DESCRIPTION
This PR adds a reusable `ObjectOutputPins` type. It represents a collection of output pins for a node capable of outputting the properties of an object or value type.

This is useful for nodes that output an object where each property is represented by a pin, this happens in the event start-nodes and the newly added list predicate node (also in this PR).

I also sneaked unrelated performance tweaks into here, I'm not used to branching much on this project ^^