### PR TITLE
add Microsoft.Windows.Compatibility 6.0.0 dependency

### DIFF
--- a/src/Artemis.UI.Windows/Artemis.UI.Windows.csproj
+++ b/src/Artemis.UI.Windows/Artemis.UI.Windows.csproj
@@ -39,6 +39,7 @@
         <PackageReference Include="Avalonia.Win32" Version="0.10.18" />
         <PackageReference Include="Microsoft.Toolkit.Uwp.Notifications" Version="7.1.2" />
         <PackageReference Include="Microsoft.Win32" Version="2.0.1" />
+        <PackageReference Include="Microsoft.Windows.Compatibility" Version="6.0.0" />
         <PackageReference Include="RawInput.Sharp" Version="0.0.4" />
         <PackageReference Include="ReactiveUI" Version="17.1.50" />
         <PackageReference Include="SkiaSharp.Vulkan.SharpVk" Version="2.88.1-preview.108" />


### PR DESCRIPTION
This PR aims to add more windows compatibility for plugins made in .net 6 or higher.

I didn't see any side effects from my daily usage. More intensive testing could be made.