### PR TITLE
Meta  - Changed format of the nuget version

### DIFF
--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -21,9 +21,12 @@ jobs:
         shell: pwsh
         run: |
           $MidnightUtc = [DateTime]::UtcNow.Date
+          $BranchName = "${{ github.ref_name }}".replace('/','-').replace('.','-')
           $ApiVersion = (Select-Xml -Path 'src/Artemis.Core/Artemis.Core.csproj' -XPath '//PluginApiVersion').Node.InnerText
           $NumberOfCommitsToday = (git log --after=$($MidnightUtc.ToString("o")) --oneline | Measure-Object -Line).Lines
           $VersionNumber = "$ApiVersion.$($MidnightUtc.ToString("yyyy.MMdd")).$NumberOfCommitsToday"
+          # If we're not in master, add the branch name to the version so it counts as prerelease 
+          if ($BranchName -ne "master") { $VersionNumber += "-$BranchName" }
           Write-Output "::set-output name=version-number::$VersionNumber"
 
   nuget:

--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -10,7 +10,7 @@ jobs:
   version:
     runs-on: ubuntu-latest
     outputs:
-      version-suffix: ${{ steps.get-version.outputs.version-suffix }}
+      version-number: ${{ steps.get-version.outputs.version-number }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -21,10 +21,10 @@ jobs:
         shell: pwsh
         run: |
           $MidnightUtc = [DateTime]::UtcNow.Date
-          $BranchName = "${{ github.ref_name }}".replace('/','-').replace('.','-')
+          $ApiVersion = (Select-Xml -Path 'src/Artemis.Core/Artemis.Core.csproj' -XPath '//PluginApiVersion').Node.InnerText
           $NumberOfCommitsToday = (git log --after=$($MidnightUtc.ToString("o")) --oneline | Measure-Object -Line).Lines
-          $VersionSuffix = "$BranchName.$($MidnightUtc.ToString("yyyyMMdd")).$NumberOfCommitsToday"
-          Write-Output "::set-output name=version-suffix::$VersionSuffix"
+          $VersionNumber = "$ApiVersion.$($MidnightUtc.ToString("yyyy.MMdd")).$NumberOfCommitsToday"
+          Write-Output "::set-output name=version-number::$VersionNumber"
 
   nuget:
     name: Publish Nuget Packages
@@ -38,8 +38,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Pack Artemis.Core
-        run: dotnet pack -c Release -p:VersionSuffix=${{ needs.version.outputs.version-suffix }} -p:BuildingNuget=True src/Artemis.Core/Artemis.Core.csproj
+        run: dotnet pack -c Release -p:Version=${{ needs.version.outputs.version-number }} -p:BuildingNuget=True src/Artemis.Core/Artemis.Core.csproj
       - name: Pack Artemis.UI.Shared
-        run: dotnet pack -c Release -p:VersionSuffix=${{ needs.version.outputs.version-suffix }} src/Artemis.UI.Shared/Artemis.UI.Shared.csproj
+        run: dotnet pack -c Release -p:Version=${{ needs.version.outputs.version-number }} src/Artemis.UI.Shared/Artemis.UI.Shared.csproj
       - name: Push Nugets
         run: dotnet nuget push **/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate

--- a/src/Artemis.Core/Artemis.Core.csproj
+++ b/src/Artemis.Core/Artemis.Core.csproj
@@ -10,8 +10,7 @@
         <Platforms>x64</Platforms>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <PackageId>ArtemisRGB.Core</PackageId>
-        <!-- API Version -->
-        <VersionPrefix>1.0.0.0</VersionPrefix>
+        <PluginApiVersion>1</PluginApiVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Artemis.Core/Artemis.Core.csproj
+++ b/src/Artemis.Core/Artemis.Core.csproj
@@ -14,6 +14,11 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <!--Used to embed the above PluginApiVersion property into the assembly as metadata-->
+        <AssemblyMetadata Include="PluginApiVersion" Value="$(PluginApiVersion)" />
+    </ItemGroup>
+
+    <ItemGroup>
         <ProjectReference Include="..\Artemis.Storage\Artemis.Storage.csproj"/>
         <ProjectReference Condition="'$(BuildingNuget)' == 'True'" Update="..\Artemis.Storage\Artemis.Storage.csproj" PrivateAssets="All"/>
         

--- a/src/Artemis.Core/Constants.cs
+++ b/src/Artemis.Core/Constants.cs
@@ -61,7 +61,7 @@ public static class Constants
     /// <summary>
     ///     The current API version for plugins
     /// </summary>
-    public static readonly Version PluginApi = CoreAssembly.GetName().Version!;
+    public static readonly int PluginApiVersion = CoreAssembly.GetName().Version.Major;
 
     /// <summary>
     ///     The plugin info used by core components of Artemis

--- a/src/Artemis.Core/Constants.cs
+++ b/src/Artemis.Core/Constants.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using Artemis.Core.JsonConverters;
 using Artemis.Core.Services;
@@ -61,7 +62,8 @@ public static class Constants
     /// <summary>
     ///     The current API version for plugins
     /// </summary>
-    public static readonly int PluginApiVersion = CoreAssembly.GetName().Version.Major;
+    public static readonly int PluginApiVersion = int.Parse(CoreAssembly.GetCustomAttributes<AssemblyMetadataAttribute>()
+                                                              .First(a => a.Key == "PluginApiVersion").Value);
 
     /// <summary>
     ///     The plugin info used by core components of Artemis

--- a/src/Artemis.Core/Plugins/PluginInfo.cs
+++ b/src/Artemis.Core/Plugins/PluginInfo.cs
@@ -191,7 +191,7 @@ public class PluginInfo : CorePropertyChanged, IPrerequisitesSubject
     /// <summary>
     ///     Gets a boolean indicating whether this plugin is compatible with the current operating system and API version
     /// </summary>
-    public bool IsCompatible => Platforms.MatchesCurrentOperatingSystem() && Api != null && Api >= Constants.PluginApi;
+    public bool IsCompatible => Platforms.MatchesCurrentOperatingSystem() && Api != null && Api.Major >= Constants.PluginApiVersion;
 
     internal string PreferredPluginDirectory => $"{Main.Split(".dll")[0].Replace("/", "").Replace("\\", "")}-{Guid.ToString().Substring(0, 8)}";
 


### PR DESCRIPTION
* Changes the Nuget package version to the format "PluginApiVersion.Year.MonthDay.BuildNumber-branch".
* Changes the Constants.PluginApiVersion field to be retrieved from the assembly.
* Changes plugin compatibility checking to only compare the Major component