### PR TITLE
Core - Added fading in and out of profiles

### DIFF
--- a/src/Artemis.Core/Models/Profile/Profile.cs
+++ b/src/Artemis.Core/Models/Profile/Profile.cs
@@ -125,7 +125,7 @@ public sealed class Profile : ProfileElement
                 profileScript.OnProfileRendering(canvas, canvas.LocalClipBounds);
 
             using var opacityPaint = new SKPaint();
-            if (Configuration.FadeInAndOut && Opacity != 1)
+            if (Configuration.FadeInAndOut && Opacity < 1)
                 opacityPaint.Color = new SKColor(0, 0, 0, (byte)(255d * Easings.CubicEaseInOut(Opacity)));
 
             canvas.SaveLayer(opacityPaint);

--- a/src/Artemis.Core/Models/Profile/Profile.cs
+++ b/src/Artemis.Core/Models/Profile/Profile.cs
@@ -25,7 +25,7 @@ public sealed class Profile : ProfileElement
         _scriptConfigurations = new ObservableCollection<ScriptConfiguration>();
         
         Opacity = 0d;
-        ShouldBeEnabled = true;
+        ShouldDisplay = true;
         Configuration = configuration;
         Profile = this;
         ProfileEntity = profileEntity;
@@ -83,7 +83,7 @@ public sealed class Profile : ProfileElement
 
     internal List<Exception> Exceptions { get; }
 
-    internal bool ShouldBeEnabled { get; private set; }
+    internal bool ShouldDisplay { get; set; }
 
     internal double Opacity { get; private set; }
 
@@ -106,9 +106,9 @@ public sealed class Profile : ProfileElement
 
             const double OPACITY_PER_SECOND = 1;
             
-            if (ShouldBeEnabled && Opacity < 1)
+            if (ShouldDisplay && Opacity < 1)
                 Opacity = Math.Clamp(Opacity + OPACITY_PER_SECOND * deltaTime, 0d, 1d);
-            if (!ShouldBeEnabled && Opacity > 0)
+            if (!ShouldDisplay && Opacity > 0)
                 Opacity = Math.Clamp(Opacity - OPACITY_PER_SECOND * deltaTime, 0d, 1d);
         }
     }
@@ -184,17 +184,6 @@ public sealed class Profile : ProfileElement
 
         foreach (Layer layer in GetAllLayers())
             layer.PopulateLeds(devices);
-    }
-
-    /// <summary>
-    ///     Starts the fade out process.
-    /// </summary>
-    public void FadeOut()
-    {
-        if (Disposed)
-            throw new ObjectDisposedException("Profile");
-
-        ShouldBeEnabled = false;
     }
 
     #region Overrides of BreakableModel

--- a/src/Artemis.Core/Models/Profile/Profile.cs
+++ b/src/Artemis.Core/Models/Profile/Profile.cs
@@ -123,17 +123,25 @@ public sealed class Profile : ProfileElement
 
             foreach (ProfileScript profileScript in Scripts)
                 profileScript.OnProfileRendering(canvas, canvas.LocalClipBounds);
-
-            using var opacityPaint = new SKPaint();
-            if (Configuration.FadeInAndOut && Opacity < 1)
+            
+            SKPaint? opacityPaint = null;
+            bool applyOpacityLayer = Configuration.FadeInAndOut && Opacity < 1;
+            
+            if (applyOpacityLayer)
+            {
+                opacityPaint = new SKPaint();
                 opacityPaint.Color = new SKColor(0, 0, 0, (byte)(255d * Easings.CubicEaseInOut(Opacity)));
-
-            canvas.SaveLayer(opacityPaint);
+                canvas.SaveLayer(opacityPaint);
+            }
 
             foreach (ProfileElement profileElement in Children)
                 profileElement.Render(canvas, basePosition, editorFocus);
 
-            canvas.Restore();
+            if (applyOpacityLayer)
+            {
+                canvas.Restore();
+                opacityPaint?.Dispose();
+            }
 
             foreach (ProfileScript profileScript in Scripts)
                 profileScript.OnProfileRendered(canvas, canvas.LocalClipBounds);

--- a/src/Artemis.Core/Models/ProfileConfiguration/ProfileConfiguration.cs
+++ b/src/Artemis.Core/Models/ProfileConfiguration/ProfileConfiguration.cs
@@ -21,6 +21,7 @@ public class ProfileConfiguration : BreakableModel, IStorageModel, IDisposable
     private bool _isBeingEdited;
     private bool _isMissingModule;
     private bool _isSuspended;
+    private bool _fadeInAndOut;
     private Module? _module;
 
     private string _name;
@@ -161,6 +162,15 @@ public class ProfileConfiguration : BreakableModel, IStorageModel, IDisposable
     }
 
     /// <summary>
+    ///    Gets or sets a boolean indicating whether this profile should fade in and out when enabling or disabling
+    /// </summary>
+    public bool FadeInAndOut 
+    { 
+        get => _fadeInAndOut;
+        set => SetAndNotify(ref _fadeInAndOut, value);
+    }
+
+    /// <summary>
     ///     Gets or sets the module this profile uses
     /// </summary>
     public Module? Module
@@ -272,6 +282,7 @@ public class ProfileConfiguration : BreakableModel, IStorageModel, IDisposable
         IsSuspended = Entity.IsSuspended;
         ActivationBehaviour = (ActivationBehaviour) Entity.ActivationBehaviour;
         HotkeyMode = (ProfileConfigurationHotkeyMode) Entity.HotkeyMode;
+        FadeInAndOut = Entity.FadeInAndOut;
         Order = Entity.Order;
 
         Icon.Load();
@@ -294,6 +305,7 @@ public class ProfileConfiguration : BreakableModel, IStorageModel, IDisposable
         Entity.ActivationBehaviour = (int) ActivationBehaviour;
         Entity.HotkeyMode = (int) HotkeyMode;
         Entity.ProfileCategoryId = Category.Entity.Id;
+        Entity.FadeInAndOut = FadeInAndOut;
         Entity.Order = Order;
 
         Icon.Save();

--- a/src/Artemis.Core/Services/Storage/ProfileService.cs
+++ b/src/Artemis.Core/Services/Storage/ProfileService.cs
@@ -215,9 +215,11 @@ internal class ProfileService : IProfileService
                             profileConfiguration.TryOrBreak(() => ActivateProfile(profileConfiguration), "Failed to activate profile");
                         else if (!shouldBeActive && profileConfiguration.Profile != null)
                         {
-                            if (!profileConfiguration.FadeInAndOut || profileConfiguration.Profile.FadingStatus == FadingStatus.Disabled)
+                            if (!profileConfiguration.FadeInAndOut)
                                 DeactivateProfile(profileConfiguration);
-                            else if (profileConfiguration.Profile.FadingStatus == FadingStatus.Enabled)
+                            else if (!profileConfiguration.Profile.ShouldBeEnabled && profileConfiguration.Profile.Opacity <= 0)
+                                DeactivateProfile(profileConfiguration);
+                            else if (profileConfiguration.Profile.ShouldBeEnabled && profileConfiguration.Profile.Opacity >= 1)
                                 RequestDeactivation(profileConfiguration);
                         }
 
@@ -259,7 +261,7 @@ internal class ProfileService : IProfileService
                     {
                         ProfileConfiguration profileConfiguration = profileCategory.ProfileConfigurations[j];
                         // Ensure all criteria are met before rendering
-                        if (!profileConfiguration.IsSuspended && !profileConfiguration.IsMissingModule && (profileConfiguration.ActivationConditionMet || profileConfiguration.Profile?.FadingStatus == FadingStatus.FadingOut))
+                        if (!profileConfiguration.IsSuspended && !profileConfiguration.IsMissingModule && (profileConfiguration.ActivationConditionMet || (profileConfiguration.Profile?.ShouldBeEnabled == false && profileConfiguration.Profile?.Opacity >= 0)))
                             profileConfiguration.Profile?.Render(canvas, SKPointI.Empty, null);
                     }
                     catch (Exception e)

--- a/src/Artemis.Core/Services/Storage/ProfileService.cs
+++ b/src/Artemis.Core/Services/Storage/ProfileService.cs
@@ -263,7 +263,8 @@ internal class ProfileService : IProfileService
                     {
                         ProfileConfiguration profileConfiguration = profileCategory.ProfileConfigurations[j];
                         // Ensure all criteria are met before rendering
-                        if (!profileConfiguration.IsSuspended && !profileConfiguration.IsMissingModule && (profileConfiguration.ActivationConditionMet || (profileConfiguration.Profile?.ShouldDisplay == false && profileConfiguration.Profile?.Opacity >= 0)))
+                        bool fadingOut = profileConfiguration.Profile?.ShouldDisplay == false && profileConfiguration.Profile?.Opacity > 0;
+                        if (!profileConfiguration.IsSuspended && !profileConfiguration.IsMissingModule && (profileConfiguration.ActivationConditionMet || fadingOut))
                             profileConfiguration.Profile?.Render(canvas, SKPointI.Empty, null);
                     }
                     catch (Exception e)

--- a/src/Artemis.Storage/Entities/Profile/ProfileConfigurationEntity.cs
+++ b/src/Artemis.Storage/Entities/Profile/ProfileConfigurationEntity.cs
@@ -25,4 +25,6 @@ public class ProfileConfigurationEntity
 
     public Guid ProfileCategoryId { get; set; }
     public Guid ProfileId { get; set; }
+
+    public bool FadeInAndOut { get; set; }
 }

--- a/src/Artemis.UI/Screens/Sidebar/Dialogs/ProfileConfigurationEditView.axaml
+++ b/src/Artemis.UI/Screens/Sidebar/Dialogs/ProfileConfigurationEditView.axaml
@@ -127,6 +127,9 @@
                                 </ComboBox.ItemTemplate>
                             </ComboBox>
                         </StackPanel>
+
+                        <CheckBox VerticalAlignment="Bottom" IsChecked="{CompiledBinding FadeInAndOut}" ToolTip.Tip="Smoothly animates in and out when the profile activation conditions change.">Fade when enabling and disabling</CheckBox>
+
                     </StackPanel>
                 </Border>
 

--- a/src/Artemis.UI/Screens/Sidebar/Dialogs/ProfileConfigurationEditViewModel.cs
+++ b/src/Artemis.UI/Screens/Sidebar/Dialogs/ProfileConfigurationEditViewModel.cs
@@ -30,6 +30,7 @@ public class ProfileConfigurationEditViewModel : DialogViewModelBase<ProfileConf
     private readonly IWindowService _windowService;
     private Hotkey? _disableHotkey;
     private Hotkey? _enableHotkey;
+    private bool _fadeInAndOut;
     private ProfileConfigurationHotkeyMode _hotkeyMode;
     private ProfileConfigurationIconType _iconType;
     private ObservableCollection<ProfileIconViewModel>? _materialIcons;
@@ -57,6 +58,7 @@ public class ProfileConfigurationEditViewModel : DialogViewModelBase<ProfileConf
         _profileName = _profileConfiguration.Name;
         _iconType = _profileConfiguration.Icon.IconType;
         _hotkeyMode = _profileConfiguration.HotkeyMode;
+        _fadeInAndOut = _profileConfiguration.FadeInAndOut;
         if (_profileConfiguration.EnableHotkey != null)
             _enableHotkey = new Hotkey {Key = _profileConfiguration.EnableHotkey.Key, Modifiers = _profileConfiguration.EnableHotkey.Modifiers};
         if (_profileConfiguration.DisableHotkey != null)
@@ -117,6 +119,12 @@ public class ProfileConfigurationEditViewModel : DialogViewModelBase<ProfileConf
         set => RaiseAndSetIfChanged(ref _disableHotkey, value);
     }
 
+    public bool FadeInAndOut
+    {
+        get => _fadeInAndOut;
+        set => RaiseAndSetIfChanged(ref _fadeInAndOut, value);
+    }
+
     public ObservableCollection<ProfileModuleViewModel?> Modules { get; }
 
     public ProfileModuleViewModel? SelectedModule
@@ -155,6 +163,7 @@ public class ProfileConfigurationEditViewModel : DialogViewModelBase<ProfileConf
         ProfileConfiguration.HotkeyMode = HotkeyMode;
         ProfileConfiguration.EnableHotkey = EnableHotkey;
         ProfileConfiguration.DisableHotkey = DisableHotkey;
+        ProfileConfiguration.FadeInAndOut = FadeInAndOut;
 
         await SaveIcon();
 


### PR DESCRIPTION
Example image of the UI I added:

![image](https://user-images.githubusercontent.com/29486064/204143088-eb9a5202-d8bc-4057-b6ab-b1b24413b83e.png)

changes opacity when enabling / disabling over 1 second. Fade time and easing method is not customizable.