### PR TITLE
UI - Fixed Device LED UI

### DIFF
--- a/src/Artemis.UI/Screens/Device/Tabs/DeviceLedsTabLedViewModel.cs
+++ b/src/Artemis.UI/Screens/Device/Tabs/DeviceLedsTabLedViewModel.cs
@@ -24,11 +24,7 @@ public class DeviceLedsTabLedViewModel : ViewModelBase
         get => _isSelected;
         set
         {
-            bool oldValue = _isSelected;
-            bool newValue = RaiseAndSetIfChanged(ref _isSelected, value);
-            
-            if (newValue == oldValue)
-                return;
+            RaiseAndSetIfChanged(ref _isSelected, value);
             Apply();
         }
     }

--- a/src/Artemis.UI/Screens/Device/Tabs/DeviceLedsTabLedViewModel.cs
+++ b/src/Artemis.UI/Screens/Device/Tabs/DeviceLedsTabLedViewModel.cs
@@ -24,7 +24,10 @@ public class DeviceLedsTabLedViewModel : ViewModelBase
         get => _isSelected;
         set
         {
-            if (!RaiseAndSetIfChanged(ref _isSelected, value))
+            bool oldValue = _isSelected;
+            bool newValue = RaiseAndSetIfChanged(ref _isSelected, value);
+            
+            if (newValue == oldValue)
                 return;
             Apply();
         }

--- a/src/Artemis.UI/Screens/Device/Tabs/DeviceLedsTabView.axaml
+++ b/src/Artemis.UI/Screens/Device/Tabs/DeviceLedsTabView.axaml
@@ -14,8 +14,14 @@
         <shared:ToStringConverter x:Key="ToStringConverter" />
     </UserControl.Resources>
     <DataGrid Items="{CompiledBinding LedViewModels}" CanUserSortColumns="True" AutoGenerateColumns="False">
-        <DataGrid.Columns>
-            <DataGridCheckBoxColumn Binding="{Binding IsSelected, Mode=TwoWay}" CanUserSort="False" CanUserReorder="False" Header="Highlight" />
+        <DataGrid.Columns >
+            <DataGridTemplateColumn CanUserSort="False" CanUserReorder="False" Header="Highlight"> 
+                <DataGridTemplateColumn.CellTemplate>
+                    <DataTemplate>
+                        <CheckBox IsChecked="{Binding IsSelected, Mode=TwoWay}" />
+                    </DataTemplate>
+                </DataGridTemplateColumn.CellTemplate>
+            </DataGridTemplateColumn>
             <DataGridTextColumn Binding="{Binding ArtemisLed.RgbLed.Id, Converter={StaticResource LedIdToStringConverter}, Mode=OneWay}" Header="LED ID" Width="Auto" />
             <DataGridTextColumn Binding="{Binding ArtemisLed.RgbLed.Color, Converter={StaticResource ToStringConverter}, Mode=OneWay}" Header="Color (ARGB)" Width="Auto" CanUserSort="False" />
             <DataGridTextColumn Binding="{Binding ArtemisLed.Layout.Image, Converter={StaticResource UriToFileNameConverter}, Mode=OneWay}" Header="Image file" CanUserSort="False" />


### PR DESCRIPTION
DataGridColumnCheckbox only updates the Checked property once another row is checked. Adding a checkbox manually makes the table behave as expected.