### PR TITLE
Rgb.net update

### DIFF
--- a/src/Artemis.Core/Artemis.Core.csproj
+++ b/src/Artemis.Core/Artemis.Core.csproj
@@ -42,9 +42,9 @@
         <PackageReference Include="LiteDB" Version="5.0.12" />
         <PackageReference Include="McMaster.NETCore.Plugins" Version="1.4.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-        <PackageReference Include="RGB.NET.Core" Version="2.0.0-prerelease.12" />
-        <PackageReference Include="RGB.NET.Layout" Version="2.0.0-prerelease.12" />
-        <PackageReference Include="RGB.NET.Presets" Version="2.0.0-prerelease.12" />
+        <PackageReference Include="RGB.NET.Core" Version="2.0.0-prerelease.17" />
+        <PackageReference Include="RGB.NET.Layout" Version="2.0.0-prerelease.17" />
+        <PackageReference Include="RGB.NET.Presets" Version="2.0.0-prerelease.17" />
         <PackageReference Include="Serilog" Version="2.11.0" />
         <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
         <PackageReference Include="Serilog.Sinks.Debug" Version="2.0.0" />

--- a/src/Artemis.UI.Shared/Artemis.UI.Shared.csproj
+++ b/src/Artemis.UI.Shared/Artemis.UI.Shared.csproj
@@ -20,7 +20,7 @@
         <PackageReference Include="Material.Icons.Avalonia" Version="1.1.10" />
         <PackageReference Include="ReactiveUI" Version="17.1.50" />
         <PackageReference Include="ReactiveUI.Validation" Version="2.2.1" />
-        <PackageReference Include="RGB.NET.Core" Version="2.0.0-prerelease.12" />
+        <PackageReference Include="RGB.NET.Core" Version="2.0.0-prerelease.17" />
         <PackageReference Include="SkiaSharp" Version="2.88.1-preview.108" />
     </ItemGroup>
     <ItemGroup>

--- a/src/Artemis.UI/Artemis.UI.csproj
+++ b/src/Artemis.UI/Artemis.UI.csproj
@@ -31,8 +31,8 @@
         <PackageReference Include="Material.Icons.Avalonia" Version="1.1.10" />
         <PackageReference Include="ReactiveUI" Version="17.1.50" />
         <PackageReference Include="ReactiveUI.Validation" Version="2.2.1" />
-        <PackageReference Include="RGB.NET.Core" Version="2.0.0-prerelease.12" />
-        <PackageReference Include="RGB.NET.Layout" Version="2.0.0-prerelease.12" />
+        <PackageReference Include="RGB.NET.Core" Version="2.0.0-prerelease.17" />
+        <PackageReference Include="RGB.NET.Layout" Version="2.0.0-prerelease.17" />
         <PackageReference Include="SkiaSharp" Version="2.88.1-preview.108" />
         <PackageReference Include="Splat.DryIoc" Version="14.6.1" />
     </ItemGroup>


### PR DESCRIPTION
Needed for https://github.com/Artemis-RGB/Artemis.Plugins/pull/168

> This update contains breaking changes for other device providers (all in plugins are fixed)!

All underlying changes: https://github.com/DarthAffe/RGB.NET/compare/6e313ea..4675349