### PR TITLE
UI - Added Matomo campaign to URLs so we know whether they're used

### DIFF
--- a/src/Artemis.UI/Screens/Debugger/Tabs/Performance/PerformanceDebugView.axaml
+++ b/src/Artemis.UI/Screens/Debugger/Tabs/Performance/PerformanceDebugView.axaml
@@ -17,7 +17,7 @@
                 <TextBlock TextWrapping="Wrap" Classes="subtitle" Margin="0 10">
                     These performance stats are rather basic, for advanced performance profiling check out the wiki.
                 </TextBlock>
-                <controls:HyperlinkButton Grid.Column="1" NavigateUri="https://wiki.artemis-rgb.com/en/guides/user/plugins/profiling">
+                <controls:HyperlinkButton Grid.Column="1" NavigateUri="https://wiki.artemis-rgb.com/en/guides/user/plugins/profiling?mtm_campaign=artemis&mtm_kwd=debugger">
                     JetBrains Profiling Guide
                 </controls:HyperlinkButton>
             </Grid>

--- a/src/Artemis.UI/Screens/Device/Tabs/DevicePropertiesTabView.axaml
+++ b/src/Artemis.UI/Screens/Device/Tabs/DevicePropertiesTabView.axaml
@@ -180,7 +180,7 @@
                     </Button>
                 </Grid>
 
-                <controls:HyperlinkButton NavigateUri="https://wiki.artemis-rgb.com/en/guides/developer/layouts" Margin="0 20" HorizontalAlignment="Right">
+                <controls:HyperlinkButton NavigateUri="https://wiki.artemis-rgb.com/en/guides/developer/layouts?mtm_campaign=artemis&mtm_kwd=device-properties" Margin="0 20" HorizontalAlignment="Right">
                     Learn more about layouts on the wiki
                 </controls:HyperlinkButton>
             </StackPanel>

--- a/src/Artemis.UI/Screens/Home/HomeView.axaml
+++ b/src/Artemis.UI/Screens/Home/HomeView.axaml
@@ -43,7 +43,7 @@
 								Under Settings > Plugins you can find your currently installed plugins, these default plugins are created by Artemis developers. We're also keeping track of a list of third-party plugins on our wiki.
 							</TextBlock>
 						</StackPanel>
-						<controls:HyperlinkButton Grid.Row="1" Grid.ColumnSpan="2" Grid.Column="0" NavigateUri="https://wiki.artemis-rgb.com/en/guides/user/plugins" HorizontalAlignment="Right">
+						<controls:HyperlinkButton Grid.Row="1" Grid.ColumnSpan="2" Grid.Column="0" NavigateUri="https://wiki.artemis-rgb.com/en/guides/user/plugins?mtm_campaign=artemis&mtm_kwd=home" HorizontalAlignment="Right">
 							<controls:HyperlinkButton.ContextMenu>
 								<ContextMenu>
 									<MenuItem Header="Test"></MenuItem>
@@ -75,7 +75,7 @@
 										<TextBlock Margin="8 0 0 0" VerticalAlignment="Center">GitHub</TextBlock>
 									</StackPanel>
 								</controls:HyperlinkButton>
-								<controls:HyperlinkButton Grid.Row="0" HorizontalAlignment="Right" NavigateUri="https://artemis-rgb.com">
+								<controls:HyperlinkButton Grid.Row="0" HorizontalAlignment="Right" NavigateUri="https://artemis-rgb.com?mtm_campaign=artemis&mtm_kwd=home">
 									<StackPanel Orientation="Horizontal">
 										<avalonia:MaterialIcon Kind="Web" />
 										<TextBlock Margin="8 0 0 0" VerticalAlignment="Center">Website</TextBlock>
@@ -110,7 +110,7 @@
 						<controls:HyperlinkButton Grid.Row="1"
 												  Grid.Column="0"
 												  HorizontalAlignment="Center"
-												  NavigateUri="https://wiki.artemis-rgb.com/en/donating">
+												  NavigateUri="https://wiki.artemis-rgb.com/en/donating?mtm_campaign=artemis&mtm_kwd=home">
 							<StackPanel Orientation="Horizontal">
 								<avalonia:MaterialIcon Kind="Gift" />
 								<TextBlock Margin="8 0 0 0" VerticalAlignment="Center">Donate</TextBlock>

--- a/src/Artemis.UI/Screens/ProfileEditor/Panels/MenuBar/MenuBarView.axaml
+++ b/src/Artemis.UI/Screens/ProfileEditor/Panels/MenuBar/MenuBarView.axaml
@@ -164,44 +164,44 @@
             </MenuItem>
         </MenuItem>
         <MenuItem Header="_Help">
-            <MenuItem Header="Artemis Wiki" Command="{CompiledBinding OpenUri}" CommandParameter="https://wiki.artemis-rgb.com/">
+            <MenuItem Header="Artemis Wiki" Command="{CompiledBinding OpenUri}" CommandParameter="https://wiki.artemis-rgb.com/?mtm_campaign=artemis&mtm_kwd=profile-editor">
                 <MenuItem.Icon>
                     <avalonia:MaterialIcon Kind="BookEdit" />
                 </MenuItem.Icon>
             </MenuItem>
             <Separator />
-            <MenuItem Header="Editor" Command="{CompiledBinding OpenUri}" CommandParameter="https://wiki.artemis-rgb.com/en/guides/user/profiles">
+            <MenuItem Header="Editor" Command="{CompiledBinding OpenUri}" CommandParameter="https://wiki.artemis-rgb.com/en/guides/user/profiles?mtm_campaign=artemis&mtm_kwd=profile-editor">
                 <MenuItem.Icon>
                     <avalonia:MaterialIcon Kind="Edit" />
                 </MenuItem.Icon>
             </MenuItem>
-            <MenuItem Header="Layers" Command="{CompiledBinding OpenUri}" CommandParameter="https://wiki.artemis-rgb.com/guides/user/profiles/layers">
+            <MenuItem Header="Layers" Command="{CompiledBinding OpenUri}" CommandParameter="https://wiki.artemis-rgb.com/guides/user/profiles/layers?mtm_campaign=artemis&mtm_kwd=profile-editor">
                 <MenuItem.Icon>
                     <avalonia:MaterialIcon Kind="Layers" />
                 </MenuItem.Icon>
             </MenuItem>
-            <MenuItem Header="Display Conditions" Command="{CompiledBinding OpenUri}" CommandParameter="https://wiki.artemis-rgb.com/guides/user/profiles/conditions">
+            <MenuItem Header="Display Conditions" Command="{CompiledBinding OpenUri}" CommandParameter="https://wiki.artemis-rgb.com/guides/user/profiles/conditions?mtm_campaign=artemis&mtm_kwd=profile-editor">
                 <MenuItem.Icon>
                     <avalonia:MaterialIcon Kind="NotEqual" />
                 </MenuItem.Icon>
             </MenuItem>
-            <MenuItem Header="Timeline" Command="{CompiledBinding OpenUri}" CommandParameter="https://wiki.artemis-rgb.com/guides/user/profiles/timeline">
+            <MenuItem Header="Timeline" Command="{CompiledBinding OpenUri}" CommandParameter="https://wiki.artemis-rgb.com/guides/user/profiles/timeline?mtm_campaign=artemis&mtm_kwd=profile-editor">
                 <MenuItem.Icon>
                     <avalonia:MaterialIcon Kind="Stopwatch" />
                 </MenuItem.Icon>
             </MenuItem>
-            <MenuItem Header="Data Bindings" Command="{CompiledBinding OpenUri}" CommandParameter="https://wiki.artemis-rgb.com/guides/user/profiles/data-bindings">
+            <MenuItem Header="Data Bindings" Command="{CompiledBinding OpenUri}" CommandParameter="https://wiki.artemis-rgb.com/guides/user/profiles/data-bindings?mtm_campaign=artemis&mtm_kwd=profile-editor">
                 <MenuItem.Icon>
                     <avalonia:MaterialIcon Kind="VectorLink" />
                 </MenuItem.Icon>
             </MenuItem>
-            <MenuItem Header="Scripting" Command="{CompiledBinding OpenUri}" CommandParameter="https://wiki.artemis-rgb.com/guides/user/profiles/scripting">
+            <MenuItem Header="Scripting" Command="{CompiledBinding OpenUri}" CommandParameter="https://wiki.artemis-rgb.com/guides/user/profiles/scripting?mtm_campaign=artemis&mtm_kwd=profile-editor">
                 <MenuItem.Icon>
                     <avalonia:MaterialIcon Kind="CodeJson" />
                 </MenuItem.Icon>
             </MenuItem>
             <Separator />
-            <MenuItem Header="Report a Bug" Command="{CompiledBinding OpenUri}" CommandParameter="https://github.com/Artemis-RGB/Artemis/issues">
+            <MenuItem Header="Report a Bug" Command="{CompiledBinding OpenUri}" CommandParameter="https://github.com/Artemis-RGB/Artemis/issues?mtm_campaign=artemis&mtm_kwd=profile-editor">
                 <MenuItem.Icon>
                     <avalonia:MaterialIcon Kind="Github" />
                 </MenuItem.Icon>

--- a/src/Artemis.UI/Screens/ProfileEditor/Panels/ProfileTree/Dialogs/LayerHintsDialogView.axaml
+++ b/src/Artemis.UI/Screens/ProfileEditor/Panels/ProfileTree/Dialogs/LayerHintsDialogView.axaml
@@ -25,7 +25,7 @@
             <controls:HyperlinkButton Grid.Row="0"
                                       Grid.Column="1"
                                       VerticalAlignment="Top"
-                                      NavigateUri="https://wiki.artemis-rgb.com/guides/user/profiles/layers/adaption-hints">
+                                      NavigateUri="https://wiki.artemis-rgb.com/guides/user/profiles/layers/adaption-hints?mtm_campaign=artemis&mtm_kwd=profile-editor">
                 Learn more about adaption hints
             </controls:HyperlinkButton>
 

--- a/src/Artemis.UI/Screens/ProfileEditor/Panels/Properties/DataBinding/DataBindingView.axaml
+++ b/src/Artemis.UI/Screens/ProfileEditor/Panels/Properties/DataBinding/DataBindingView.axaml
@@ -43,7 +43,7 @@
                 When you enable data bindings you can no longer use keyframes or normal values for this property.
             </TextBlock>
             <controls:HyperlinkButton HorizontalAlignment="Center"
-                                      NavigateUri="https://wiki.artemis-rgb.com/en/guides/user/profiles/data-bindings"
+                                      NavigateUri="https://wiki.artemis-rgb.com/en/guides/user/profiles/data-bindings?mtm_campaign=artemis&mtm_kwd=profile-editor"
                                       Margin="0 10">
                 Learn more
             </controls:HyperlinkButton>

--- a/src/Artemis.UI/Screens/Settings/Tabs/AboutTabView.axaml
+++ b/src/Artemis.UI/Screens/Settings/Tabs/AboutTabView.axaml
@@ -24,13 +24,13 @@
                 </TextBlock>
 
                 <StackPanel Grid.Row="0" Grid.Column="2" HorizontalAlignment="Right" VerticalAlignment="Bottom" Orientation="Horizontal">
-                    <controls:HyperlinkButton Classes="icon-button" ToolTip.Tip="View website" NavigateUri="https://artemis-rgb.com">
+                    <controls:HyperlinkButton Classes="icon-button" ToolTip.Tip="View website" NavigateUri="https://artemis-rgb.com?mtm_campaign=artemis&mtm_kwd=about">
                         <avalonia:MaterialIcon Kind="Web" />
                     </controls:HyperlinkButton>
                     <controls:HyperlinkButton Classes="icon-button" ToolTip.Tip="View GitHub repository" NavigateUri="https://github.com/Artemis-RGB/Artemis">
                         <avalonia:MaterialIcon Kind="Github" />
                     </controls:HyperlinkButton>
-                    <controls:HyperlinkButton Classes="icon-button" ToolTip.Tip="View Wiki" NavigateUri="https://wiki.artemis-rgb.com">
+                    <controls:HyperlinkButton Classes="icon-button" ToolTip.Tip="View Wiki" NavigateUri="https://wiki.artemis-rgb.com?mtm_campaign=artemis&mtm_kwd=about">
                         <avalonia:MaterialIcon Kind="BookOpenOutline" />
                     </controls:HyperlinkButton>
                 </StackPanel>

--- a/src/Artemis.UI/Screens/Settings/Tabs/PluginsTabView.axaml
+++ b/src/Artemis.UI/Screens/Settings/Tabs/PluginsTabView.axaml
@@ -17,7 +17,7 @@
             <TextBox Classes="clearButton" Text="{CompiledBinding SearchPluginInput}" Watermark="Search plugins" Margin="0 0 10 0" />
 
             <StackPanel Spacing="5" Grid.Row="0" Grid.Column="1" HorizontalAlignment="Right" Orientation="Horizontal">
-                <controls:HyperlinkButton VerticalAlignment="Top" NavigateUri="https://wiki.artemis-rgb.com/en/guides/user/plugins">
+                <controls:HyperlinkButton VerticalAlignment="Top" NavigateUri="https://wiki.artemis-rgb.com/en/guides/user/plugins?mtm_campaign=artemis&mtm_kwd=plugins">
                     Get more plugins
                 </controls:HyperlinkButton>
                 <Button Classes="accent" Command="{CompiledBinding ImportPlugin}">Import plugin</Button>

--- a/src/Artemis.UI/Screens/Settings/Tabs/ReleasesTabView.axaml
+++ b/src/Artemis.UI/Screens/Settings/Tabs/ReleasesTabView.axaml
@@ -28,7 +28,7 @@
                            TextWrapping="Wrap"
                            Text="{CompiledBinding Channel, StringFormat='Found no releases for the \'{0}\' channel.'}">
                 </TextBlock>
-                <controls:HyperlinkButton NavigateUri="https://wiki.artemis-rgb.com/en/channels"
+                <controls:HyperlinkButton NavigateUri="https://wiki.artemis-rgb.com/en/channels?mtm_campaign=artemis&mtm_kwd=releases"
                                           HorizontalAlignment="Center">
                     Learn more about channels on the wiki
                 </controls:HyperlinkButton>

--- a/src/Artemis.UI/Screens/Sidebar/SidebarView.axaml
+++ b/src/Artemis.UI/Screens/Sidebar/SidebarView.axaml
@@ -47,7 +47,7 @@
                                       ToolTip.Tip="View website"
                                       ToolTip.Placement="Top"
                                       ToolTip.VerticalOffset="-5"
-                                      NavigateUri="https://artemis-rgb.com">
+                                      NavigateUri="https://artemis-rgb.com?mtm_campaign=artemis&mtm_kwd=sidebar">
                 <avalonia:MaterialIcon Kind="Web" Width="20" Height="20" />
             </controls:HyperlinkButton>
             <controls:HyperlinkButton Classes="icon-button"
@@ -65,7 +65,7 @@
                                       ToolTip.Tip="View Wiki"
                                       ToolTip.Placement="Top"
                                       ToolTip.VerticalOffset="-5"
-                                      NavigateUri="https://wiki.artemis-rgb.com">
+                                      NavigateUri="https://wiki.artemis-rgb.com?mtm_campaign=artemis&mtm_kwd=sidebar">
                 <avalonia:MaterialIcon Kind="BookOpenOutline" Width="20" Height="20" />
             </controls:HyperlinkButton>
             <controls:HyperlinkButton Classes="icon-button"
@@ -83,7 +83,7 @@
                                       ToolTip.Tip="View donation options"
                                       ToolTip.Placement="Top"
                                       ToolTip.VerticalOffset="-5"
-                                      NavigateUri="https://wiki.artemis-rgb.com/en/donating">
+                                      NavigateUri="https://wiki.artemis-rgb.com/en/donating?mtm_campaign=artemis&mtm_kwd=sidebar">
                 <avalonia:MaterialIcon Kind="Gift" Width="20" Height="20" />
             </controls:HyperlinkButton>
         </WrapPanel>

--- a/src/Artemis.UI/Screens/StartupWizard/Steps/FinishStep.axaml
+++ b/src/Artemis.UI/Screens/StartupWizard/Steps/FinishStep.axaml
@@ -33,10 +33,10 @@
                     <TextBlock Classes="link-name">Discord</TextBlock>
                 </StackPanel>
                 <StackPanel Grid.Column="1">
-                    <controls:HyperlinkButton NavigateUri="https://wiki.artemis-rgb.com/">
+                    <controls:HyperlinkButton NavigateUri="https://wiki.artemis-rgb.com/?mtm_campaign=artemis&mtm_kwd=wizard">
                         https://wiki.artemis-rgb.com/
                     </controls:HyperlinkButton>
-                    <controls:HyperlinkButton NavigateUri="https://wiki.artemis-rgb.com/en/guides/user/introduction">
+                    <controls:HyperlinkButton NavigateUri="https://wiki.artemis-rgb.com/en/guides/user/introduction?mtm_campaign=artemis&mtm_kwd=wizard">
                         https://wiki.artemis-rgb.com/en/guides/user/introduction
                     </controls:HyperlinkButton>
                     <controls:HyperlinkButton NavigateUri="https://github.com/Artemis-RGB/Artemis">

--- a/src/Artemis.UI/Screens/StartupWizard/Steps/WelcomeStep.axaml
+++ b/src/Artemis.UI/Screens/StartupWizard/Steps/WelcomeStep.axaml
@@ -16,13 +16,13 @@
             </TextBlock>
 
             <StackPanel Grid.Row="0" Grid.Column="2" HorizontalAlignment="Right" VerticalAlignment="Bottom" Orientation="Horizontal">
-                <controls:HyperlinkButton Classes="icon-button" ToolTip.Tip="View website" NavigateUri="https://artemis-rgb.com">
+                <controls:HyperlinkButton Classes="icon-button" ToolTip.Tip="View website" NavigateUri="https://artemis-rgb.com?mtm_campaign=artemis&mtm_kwd=wizard">
                     <avalonia:MaterialIcon Kind="Web" />
                 </controls:HyperlinkButton>
                 <controls:HyperlinkButton Classes="icon-button" ToolTip.Tip="View GitHub repository" NavigateUri="https://github.com/Artemis-RGB/Artemis">
                     <avalonia:MaterialIcon Kind="Github" />
                 </controls:HyperlinkButton>
-                <controls:HyperlinkButton Classes="icon-button" ToolTip.Tip="View Wiki" NavigateUri="https://wiki.artemis-rgb.com">
+                <controls:HyperlinkButton Classes="icon-button" ToolTip.Tip="View Wiki" NavigateUri="https://wiki.artemis-rgb.com?mtm_campaign=artemis&mtm_kwd=wizard">
                     <avalonia:MaterialIcon Kind="BookOpenOutline" />
                 </controls:HyperlinkButton>
             </StackPanel>

--- a/src/Artemis.UI/Screens/VisualScripting/NodeScriptWindowView.axaml
+++ b/src/Artemis.UI/Screens/VisualScripting/NodeScriptWindowView.axaml
@@ -116,38 +116,38 @@
                 </MenuItem>
             </MenuItem>
             <MenuItem Header="_Help">
-                <MenuItem Header="Artemis Wiki" Command="{CompiledBinding OpenUri}" CommandParameter="https://wiki.artemis-rgb.com/">
+                <MenuItem Header="Artemis Wiki" Command="{CompiledBinding OpenUri}" CommandParameter="https://wiki.artemis-rgb.com/?mtm_campaign=artemis&mtm_kwd=script-editor">
                     <MenuItem.Icon>
                         <avalonia:MaterialIcon Kind="BookEdit" />
                     </MenuItem.Icon>
                 </MenuItem>
                 <Separator />
-                <MenuItem Header="Editor" Command="{CompiledBinding OpenUri}" CommandParameter="https://wiki.artemis-rgb.com/en/guides/user/profiles">
+                <MenuItem Header="Editor" Command="{CompiledBinding OpenUri}" CommandParameter="https://wiki.artemis-rgb.com/en/guides/user/profiles?mtm_campaign=artemis&mtm_kwd=script-editor">
                     <MenuItem.Icon>
                         <avalonia:MaterialIcon Kind="Edit" />
                     </MenuItem.Icon>
                 </MenuItem>
-                <MenuItem Header="Layers" Command="{CompiledBinding OpenUri}" CommandParameter="https://wiki.artemis-rgb.com/guides/user/profiles/layers">
+                <MenuItem Header="Layers" Command="{CompiledBinding OpenUri}" CommandParameter="https://wiki.artemis-rgb.com/guides/user/profiles/layers?mtm_campaign=artemis&mtm_kwd=script-editor">
                     <MenuItem.Icon>
                         <avalonia:MaterialIcon Kind="Layers" />
                     </MenuItem.Icon>
                 </MenuItem>
-                <MenuItem Header="Display Conditions" Command="{CompiledBinding OpenUri}" CommandParameter="https://wiki.artemis-rgb.com/guides/user/profiles/conditions">
+                <MenuItem Header="Display Conditions" Command="{CompiledBinding OpenUri}" CommandParameter="https://wiki.artemis-rgb.com/guides/user/profiles/conditions?mtm_campaign=artemis&mtm_kwd=script-editor">
                     <MenuItem.Icon>
                         <avalonia:MaterialIcon Kind="NotEqual" />
                     </MenuItem.Icon>
                 </MenuItem>
-                <MenuItem Header="Timeline" Command="{CompiledBinding OpenUri}" CommandParameter="https://wiki.artemis-rgb.com/guides/user/profiles/timeline">
+                <MenuItem Header="Timeline" Command="{CompiledBinding OpenUri}" CommandParameter="https://wiki.artemis-rgb.com/guides/user/profiles/timeline?mtm_campaign=artemis&mtm_kwd=script-editor">
                     <MenuItem.Icon>
                         <avalonia:MaterialIcon Kind="Stopwatch" />
                     </MenuItem.Icon>
                 </MenuItem>
-                <MenuItem Header="Data Bindings" Command="{CompiledBinding OpenUri}" CommandParameter="https://wiki.artemis-rgb.com/guides/user/profiles/data-bindings">
+                <MenuItem Header="Data Bindings" Command="{CompiledBinding OpenUri}" CommandParameter="https://wiki.artemis-rgb.com/guides/user/profiles/data-bindings?mtm_campaign=artemis&mtm_kwd=script-editor">
                     <MenuItem.Icon>
                         <avalonia:MaterialIcon Kind="VectorLink" />
                     </MenuItem.Icon>
                 </MenuItem>
-                <MenuItem Header="Scripting" Command="{CompiledBinding OpenUri}" CommandParameter="https://wiki.artemis-rgb.com/guides/user/profiles/scripting">
+                <MenuItem Header="Scripting" Command="{CompiledBinding OpenUri}" CommandParameter="https://wiki.artemis-rgb.com/guides/user/profiles/scripting?mtm_campaign=artemis&mtm_kwd=script-editor">
                     <MenuItem.Icon>
                         <avalonia:MaterialIcon Kind="CodeJson" />
                     </MenuItem.Icon>
@@ -173,7 +173,7 @@
                                   Grid.Column="1"
                                   VerticalAlignment="Top"
                                   HorizontalAlignment="Right"
-                                  NavigateUri="https://wiki.artemis-rgb.com/en/guides/user/profiles/nodes">
+                                  NavigateUri="https://wiki.artemis-rgb.com/en/guides/user/profiles/nodes?mtm_campaign=artemis&mtm_kwd=script-editor">
             Learn more about visual scripts
         </controls:HyperlinkButton>
 

--- a/src/Artemis.VisualScripting/Nodes/Mathematics/MathExpressionNode.cs
+++ b/src/Artemis.VisualScripting/Nodes/Mathematics/MathExpressionNode.cs
@@ -5,7 +5,7 @@ using NoStringEvaluating.Models.FormulaChecker;
 
 namespace Artemis.VisualScripting.Nodes.Mathematics;
 
-[Node("Math Expression", "Outputs the result of a math expression.", "Mathematics", "https://wiki.artemis-rgb.com/en/guides/user/profiles/nodes/mathematics/math-expression", InputType = typeof(Numeric), OutputType = typeof(Numeric))]
+[Node("Math Expression", "Outputs the result of a math expression.", "Mathematics", "https://wiki.artemis-rgb.com/en/guides/user/profiles/nodes/mathematics/math-expression?mtm_campaign=artemis&mtm_kwd=node-help", InputType = typeof(Numeric), OutputType = typeof(Numeric))]
 public class MathExpressionNode : Node<string, MathExpressionNodeCustomViewModel>
 {
     private readonly IFormulaChecker _checker;


### PR DESCRIPTION
In order to get a view on whether people use the URLs in the application, I've added `mtm_campaign` and `mtm_kwd` GET parameters to all URLs.

I don't want to go as far as to add actual telemetry to Artemis, but this allows us to at least know whether people visit the Wiki from the application.