### PR TITLE
Fixed a few annoying UI bugs

### DIFF
--- a/src/Artemis.Core/ColorScience/Quantization/ColorSwatch.cs
+++ b/src/Artemis.Core/ColorScience/Quantization/ColorSwatch.cs
@@ -1,4 +1,5 @@
-﻿using SkiaSharp;
+﻿using System.Text;
+using SkiaSharp;
 
 namespace Artemis.Core.ColorScience;
 
@@ -36,4 +37,14 @@ public readonly record struct ColorSwatch
     ///     The <see cref="ColorType.DarkMuted" /> component.
     /// </summary>
     public SKColor DarkMuted { get; init; }
+
+    /// <summary>
+    ///     Override the record ToString method,
+    ///     so we get a cleaner datamodel viewer
+    /// </summary>
+    /// <returns></returns>
+    public override string? ToString()
+    {
+        return base.ToString();
+    }
 }

--- a/src/Artemis.Core/Services/WebServer/PluginsModule.cs
+++ b/src/Artemis.Core/Services/WebServer/PluginsModule.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using EmbedIO;
@@ -15,7 +16,7 @@ public class PluginsModule : WebModuleBase
 
     internal PluginsModule(string baseRoute) : base(baseRoute)
     {
-        _pluginEndPoints = new Dictionary<string, Dictionary<string, PluginEndPoint>>();
+        _pluginEndPoints = new Dictionary<string, Dictionary<string, PluginEndPoint>>(comparer: StringComparer.InvariantCultureIgnoreCase);
     }
 
     internal void AddPluginEndPoint(PluginEndPoint registration)

--- a/src/Artemis.UI/Screens/Debugger/Tabs/Logs/LogsDebugView.axaml
+++ b/src/Artemis.UI/Screens/Debugger/Tabs/Logs/LogsDebugView.axaml
@@ -2,13 +2,16 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             xmlns:aedit="https://github.com/avaloniaui/avaloniaedit"
-             xmlns:controls="clr-namespace:Artemis.UI.Controls"
              xmlns:logs="clr-namespace:Artemis.UI.Screens.Debugger.Logs"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="Artemis.UI.Screens.Debugger.Logs.LogsDebugView"
              x:DataType="logs:LogsDebugViewModel">
     <ScrollViewer Name="LogsScrollViewer" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto">
-        <SelectableTextBlock Inlines="{CompiledBinding Lines}" FontFamily="Consolas" SizeChanged="Control_OnSizeChanged"></SelectableTextBlock>    
+        <SelectableTextBlock 
+            Inlines="{CompiledBinding Lines}" 
+            FontFamily="Consolas" 
+            SizeChanged="Control_OnSizeChanged" 
+            SelectionBrush="{StaticResource TextControlSelectionHighlightColor}"
+        />    
     </ScrollViewer>
 </UserControl>

--- a/src/Artemis.UI/Screens/Debugger/Tabs/Logs/LogsDebugView.axaml.cs
+++ b/src/Artemis.UI/Screens/Debugger/Tabs/Logs/LogsDebugView.axaml.cs
@@ -10,14 +10,10 @@ namespace Artemis.UI.Screens.Debugger.Logs;
 
 public partial class LogsDebugView : ReactiveUserControl<LogsDebugViewModel>
 {
-    private int _lineCount;
-
     public LogsDebugView()
     {
-        _lineCount = 0;
         InitializeComponent();
     }
-
 
     protected override void OnInitialized()
     {
@@ -25,35 +21,6 @@ public partial class LogsDebugView : ReactiveUserControl<LogsDebugViewModel>
         Dispatcher.UIThread.Post(() => LogsScrollViewer.ScrollToEnd(), DispatcherPriority.ApplicationIdle);
     }
 
-    // private void OnTextChanged(object? sender, EventArgs e)
-    // {
-    //     if (LogTextEditor.ExtentHeight == 0)
-    //         return;
-    //
-    //     int linesAdded = LogTextEditor.LineCount - _lineCount;
-    //     double lineHeight = LogTextEditor.ExtentHeight / LogTextEditor.LineCount;
-    //     double outOfScreenTextHeight = LogTextEditor.ExtentHeight - LogTextEditor.VerticalOffset - LogTextEditor.ViewportHeight;
-    //     double outOfScreenLines = outOfScreenTextHeight / lineHeight;
-    //
-    //     //we need this help distance because of rounding.
-    //     //if we scroll slightly above the end, we still want it
-    //     //to scroll down to the new lines.
-    //     const double GRACE_DISTANCE = 1d;
-    //
-    //     //if we were at the bottom of the log and
-    //     //if the last log event was 5 lines long
-    //     //we will be 5 lines out sync.
-    //     //if this is the case, scroll down.
-    //
-    //     //if we are more than that out of sync,
-    //     //the user scrolled up and we should not
-    //     //mess with anything.
-    //     if (_lineCount == 0 || linesAdded + GRACE_DISTANCE >  outOfScreenLines)
-    //     {
-    //         Dispatcher.UIThread.Post(() => LogTextEditor.ScrollToEnd(), DispatcherPriority.ApplicationIdle);
-    //         _lineCount = LogTextEditor.LineCount;
-    //     }
-    // }
     private void Control_OnSizeChanged(object? sender, SizeChangedEventArgs e)
     {
         if (!(LogsScrollViewer.Extent.Height - LogsScrollViewer.Offset.Y - LogsScrollViewer.Bounds.Bottom <= 60))

--- a/src/Artemis.UI/Screens/Debugger/Tabs/Logs/LogsDebugViewModel.cs
+++ b/src/Artemis.UI/Screens/Debugger/Tabs/Logs/LogsDebugViewModel.cs
@@ -7,7 +7,9 @@ using ReactiveUI;
 using Serilog.Events;
 using Serilog.Formatting.Display;
 using System.IO;
+using System.Linq;
 using System.Reactive.Disposables;
+using System.Text;
 using Avalonia.Controls.Documents;
 using Avalonia.Media;
 
@@ -54,8 +56,14 @@ public class LogsDebugViewModel : ActivatableViewModelBase
         _formatter.Format(logEvent, writer);
         string line = writer.ToString();
 
+        StringBuilder builder = new();
 
-        Lines.Add(new Run(line.TrimEnd('\r', '\n') + '\n')
+        //hack: https://github.com/AvaloniaUI/Avalonia/issues/10913
+        string paddedLine2 = line.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries)
+            .Aggregate(builder, (sb, s) => sb.Append(s).Append(' ', 400 - s.Length).AppendLine())
+            .ToString();
+
+        Lines.Add(new Run(paddedLine2)
         {
             Foreground = logEvent.Level switch
             {

--- a/src/Artemis.UI/Screens/Debugger/Tabs/Logs/LogsDebugViewModel.cs
+++ b/src/Artemis.UI/Screens/Debugger/Tabs/Logs/LogsDebugViewModel.cs
@@ -56,14 +56,7 @@ public class LogsDebugViewModel : ActivatableViewModelBase
         _formatter.Format(logEvent, writer);
         string line = writer.ToString();
 
-        StringBuilder builder = new();
-
-        //hack: https://github.com/AvaloniaUI/Avalonia/issues/10913
-        string paddedLine2 = line.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries)
-            .Aggregate(builder, (sb, s) => sb.Append(s).Append(' ', 400 - s.Length).AppendLine())
-            .ToString();
-
-        Lines.Add(new Run(paddedLine2)
+        Lines.Add(new Run(line.TrimEnd('\r', '\n') + '\n')
         {
             Foreground = logEvent.Level switch
             {

--- a/src/Artemis.VisualScripting/Nodes/Branching/EnumSwitchNode.cs
+++ b/src/Artemis.VisualScripting/Nodes/Branching/EnumSwitchNode.cs
@@ -71,7 +71,7 @@ public class EnumSwitchNode : Node
 
         foreach (Enum enumValue in Enum.GetValues(enumType).Cast<Enum>())
         {
-            InputPin pin = CreateOrAddInputPin(typeof(object), enumValue.ToString().Humanize(LetterCasing.Sentence));
+            InputPin pin = CreateOrAddInputPin(typeof(object), enumValue.Humanize(LetterCasing.Sentence));
             pin.PinConnected += OnInputPinConnected;
             pin.PinDisconnected += OnInputPinDisconnected;
             _inputPins[enumValue] = pin;


### PR DESCRIPTION
* Added selection brush to logs window so you can actually copy paste properly-ish. blocked by https://github.com/AvaloniaUI/Avalonia/issues/10913
* Overrode the record ColorSwatch.ToString so it doesn't pollute the debugger datamodel view
* Fixed the web module treating plugin guids in the url as case-sensitive
* Fixed the enum switch node not respecting `DisplayAttribute`