### PR TITLE
Reduce memory allocation in Windows Input Provider

### DIFF
--- a/src/Artemis.UI.Windows/Providers/Input/WindowsInputProvider.cs
+++ b/src/Artemis.UI.Windows/Providers/Input/WindowsInputProvider.cs
@@ -6,7 +6,6 @@ using System.Timers;
 using Artemis.Core;
 using Artemis.Core.Services;
 using Artemis.UI.Windows.Utilities;
-using HidSharp;
 using Linearstar.Windows.RawInput;
 using Linearstar.Windows.RawInput.Native;
 using Serilog;


### PR DESCRIPTION
`RawInputData.Device.Path` is sneaky, but it allocates significant memory when executed like we are doing it. To get identifiers every frame we should cache it somehow. I don't know if this way is perfect, but it's an improvement, accepting feedback on this and also about the removal of OnIdentifierReceived.