### PR TITLE
Profiler - Added number of calls

### DIFF
--- a/src/Artemis.Core/Plugins/Profiling/ProfilingMeasurement.cs
+++ b/src/Artemis.Core/Plugins/Profiling/ProfilingMeasurement.cs
@@ -14,6 +14,7 @@ public class ProfilingMeasurement
     private long _last;
     private bool _open;
     private long _start;
+    private ulong _count;
 
     internal ProfilingMeasurement(string identifier)
     {
@@ -59,6 +60,7 @@ public class ProfilingMeasurement
             _filledArray = true;
             _index = 0;
         }
+        _count++;
 
         _last = difference;
         return difference;
@@ -124,6 +126,14 @@ public class ProfilingMeasurement
             : Measurements.Take(_index).OrderBy(l => l).ToArray();
 
         return new TimeSpan((long) Percentile(collection, percentile));
+    }
+
+    /// <summary>
+    ///     Gets the number of measurements taken
+    /// </summary>
+    public ulong GetCount()
+    {
+        return _count;
     }
 
     private static double Percentile(long[] elements, double percentile)

--- a/src/Artemis.UI/Screens/Debugger/Tabs/Performance/PerformanceDebugMeasurementViewModel.cs
+++ b/src/Artemis.UI/Screens/Debugger/Tabs/Performance/PerformanceDebugMeasurementViewModel.cs
@@ -10,6 +10,7 @@ public class PerformanceDebugMeasurementViewModel : ViewModelBase
     private string? _max;
     private string? _min;
     private string? _percentile;
+    private string? _count;
 
     public PerformanceDebugMeasurementViewModel(ProfilingMeasurement measurement)
     {
@@ -47,6 +48,12 @@ public class PerformanceDebugMeasurementViewModel : ViewModelBase
         get => _percentile;
         set => RaiseAndSetIfChanged(ref _percentile, value);
     }
+    
+    public string? Count
+    {
+        get => _count;
+        set => RaiseAndSetIfChanged(ref _count, value);
+    }
 
     public void Update()
     {
@@ -55,5 +62,6 @@ public class PerformanceDebugMeasurementViewModel : ViewModelBase
         Min = Measurement.GetMin().TotalMilliseconds + " ms";
         Max = Measurement.GetMax().TotalMilliseconds + " ms";
         Percentile = Measurement.GetPercentile(0.95).TotalMilliseconds + " ms";
+        Count = Measurement.GetCount().ToString();
     }
 }

--- a/src/Artemis.UI/Screens/Debugger/Tabs/Performance/PerformanceDebugProfilerView.axaml
+++ b/src/Artemis.UI/Screens/Debugger/Tabs/Performance/PerformanceDebugProfilerView.axaml
@@ -23,6 +23,7 @@
                 <DataGridTextColumn Binding="{CompiledBinding Max}" Header="Max" />
                 <DataGridTextColumn Binding="{CompiledBinding Average}" Header="Average" />
                 <DataGridTextColumn Binding="{CompiledBinding Percentile}" Header="95th percentile" />
+                <DataGridTextColumn Binding="{CompiledBinding Count}" Header="Number of Calls" />
             </DataGrid.Columns>
         </DataGrid>
     </StackPanel>


### PR DESCRIPTION
This is useful to see if some profiled call is being called more often than expected. Changes and performance impact are pretty minimal so I figured it's ok to add.