### PR TITLE
Core - Further reduced allocations in process monitor checking

### DIFF
--- a/src/Artemis.Core/Plugins/Modules/ActivationRequirements/ProcessActivationRequirement.cs
+++ b/src/Artemis.Core/Plugins/Modules/ActivationRequirements/ProcessActivationRequirement.cs
@@ -38,16 +38,7 @@ public class ProcessActivationRequirement : IModuleActivationRequirement
     /// <inheritdoc />
     public bool Evaluate()
     {
-        if (!ProcessMonitor.IsStarted || (ProcessName == null && Location == null))
-            return false;
-
-        IEnumerable<ProcessInfo> processes = ProcessMonitor.Processes;
-        if (ProcessName != null)
-            processes = processes.Where(p => string.Equals(p.ProcessName, ProcessName, StringComparison.InvariantCultureIgnoreCase));
-        if (Location != null)
-            processes = processes.Where(p => string.Equals(Path.GetDirectoryName(p.Executable), Location, StringComparison.InvariantCultureIgnoreCase));
-
-        return processes.Any();
+        return ProcessMonitor.IsProcessRunning(ProcessName, Location);
     }
 
     /// <inheritdoc />

--- a/src/Artemis.Core/Plugins/Modules/ActivationRequirements/ProcessActivationRequirement.cs
+++ b/src/Artemis.Core/Plugins/Modules/ActivationRequirements/ProcessActivationRequirement.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
 using Artemis.Core.Services;
 
 namespace Artemis.Core.Modules;

--- a/src/Artemis.Core/Services/ProcessMonitoring/ProcessMonitor.cs
+++ b/src/Artemis.Core/Services/ProcessMonitoring/ProcessMonitor.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
-using System.Numerics;
 using System.Threading;
 
 namespace Artemis.Core.Services;
@@ -115,7 +114,7 @@ public static partial class ProcessMonitor
         
         lock (LOCK)
         {
-            return _processes.Values.Any(x => Match(x, processName, processLocation));
+            return _processes.Values.Any(x => IsProcessRunning(x, processName, processLocation));
         }
     }
 
@@ -132,7 +131,7 @@ public static partial class ProcessMonitor
             }
     }
         
-    private static bool Match(ProcessInfo info, string? processName, string? processLocation)
+    private static bool IsProcessRunning(ProcessInfo info, string? processName, string? processLocation)
     {
         if (processName != null && processLocation != null)
             return string.Equals(info.ProcessName, processName, StringComparison.InvariantCultureIgnoreCase) &&

--- a/src/Artemis.Core/Services/ProcessMonitoring/ProcessMonitor.cs
+++ b/src/Artemis.Core/Services/ProcessMonitoring/ProcessMonitor.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.IO;
 using System.Linq;
+using System.Numerics;
 using System.Threading;
 
 namespace Artemis.Core.Services;
@@ -99,6 +101,23 @@ public static partial class ProcessMonitor
                 FreeBuffer();
         }
     }
+    
+    /// <summary>
+    ///     Returns whether the specified process is running
+    /// </summary>
+    /// <param name="processName">The name of the process to check</param>
+    /// <param name="processLocation">The location of where the process must be running from (optional)</param>
+    /// <returns></returns>
+    public static bool IsProcessRunning(string? processName = null, string? processLocation = null)
+    {
+        if (!IsStarted || (processName == null && processLocation == null))
+            return false;
+        
+        lock (LOCK)
+        {
+            return _processes.Values.Any(x => Match(x, processName, processLocation));
+        }
+    }
 
     // ReSharper disable once SuggestBaseTypeForParameter
     private static void HandleStoppedProcesses(HashSet<int> currentProcessIds)
@@ -111,6 +130,21 @@ public static partial class ProcessMonitor
                 _processes.Remove(id);
                 OnProcessStopped(info);
             }
+    }
+        
+    private static bool Match(ProcessInfo info, string? processName, string? processLocation)
+    {
+        if (processName != null && processLocation != null)
+            return string.Equals(info.ProcessName, processName, StringComparison.InvariantCultureIgnoreCase) &&
+                   string.Equals(Path.GetDirectoryName(info.Executable), processLocation, StringComparison.InvariantCultureIgnoreCase);
+        
+        if (processName != null)
+            return string.Equals(info.ProcessName, processName, StringComparison.InvariantCultureIgnoreCase);
+        
+        if (processLocation != null)
+            return string.Equals(Path.GetDirectoryName(info.Executable), processLocation, StringComparison.InvariantCultureIgnoreCase);
+        
+        return false;
     }
 
     private static void OnProcessStarted(ProcessInfo processInfo)


### PR DESCRIPTION
Avoids `ToArray` being called everytime a process needs to be checked.