### PR TITLE
Meta - Clean up nuget package references

### DIFF
--- a/src/Artemis.Core/Artemis.Core.csproj
+++ b/src/Artemis.Core/Artemis.Core.csproj
@@ -36,20 +36,20 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="DryIoc.dll" Version="5.4.2" />
+        <PackageReference Include="DryIoc.dll" Version="5.4.3" />
         <PackageReference Include="EmbedIO" Version="3.5.2" />
         <PackageReference Include="HidSharp" Version="2.1.0" />
         <PackageReference Include="Humanizer.Core" Version="2.14.1" />
-        <PackageReference Include="JetBrains.Annotations" Version="2023.2.0" />
+        <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" />
         <PackageReference Include="McMaster.NETCore.Plugins" Version="1.4.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-        <PackageReference Include="RGB.NET.Core" Version="2.0.0-prerelease.125" />
-        <PackageReference Include="RGB.NET.Layout" Version="2.0.0-prerelease.125" />
-        <PackageReference Include="RGB.NET.Presets" Version="2.0.0-prerelease.125" />
-        <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
+        <PackageReference Include="RGB.NET.Core" Version="2.0.4-prerelease.1" />
+        <PackageReference Include="RGB.NET.Layout" Version="2.0.4-prerelease.1" />
+        <PackageReference Include="RGB.NET.Presets" Version="2.0.4-prerelease.1" />
+        <PackageReference Include="Serilog.Sinks.Console" Version="5.0.1" />
         <PackageReference Include="Serilog.Sinks.Debug" Version="2.0.0" />
         <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
-        <PackageReference Include="SkiaSharp" Version="2.88.6" />
+        <PackageReference Include="SkiaSharp" Version="2.88.7" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Artemis.Core/Artemis.Core.csproj
+++ b/src/Artemis.Core/Artemis.Core.csproj
@@ -1,6 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-    <Import Project="..\Artemis.props" />
-    
     <PropertyGroup>
         <TargetFramework>net7.0</TargetFramework>
         <PreserveCompilationContext>false</PreserveCompilationContext>
@@ -45,14 +43,13 @@
         <PackageReference Include="JetBrains.Annotations" Version="2023.2.0" />
         <PackageReference Include="McMaster.NETCore.Plugins" Version="1.4.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-        <PackageReference Include="RGB.NET.Core" Version="$(RGBDotNetVersion)" />
-        <PackageReference Include="RGB.NET.Layout" Version="$(RGBDotNetVersion)" />
-        <PackageReference Include="RGB.NET.Presets" Version="$(RGBDotNetVersion)" />
-        <PackageReference Include="Serilog" Version="3.0.1" />
+        <PackageReference Include="RGB.NET.Core" Version="2.0.0-prerelease.125" />
+        <PackageReference Include="RGB.NET.Layout" Version="2.0.0-prerelease.125" />
+        <PackageReference Include="RGB.NET.Presets" Version="2.0.0-prerelease.125" />
         <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
         <PackageReference Include="Serilog.Sinks.Debug" Version="2.0.0" />
         <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
-        <PackageReference Include="SkiaSharp" Version="$(SkiaSharpVersion)" />
+        <PackageReference Include="SkiaSharp" Version="2.88.6" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Artemis.Core/Artemis.Core.csproj
+++ b/src/Artemis.Core/Artemis.Core.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
     <Import Project="..\Artemis.props" />
     
     <PropertyGroup>
@@ -43,31 +43,20 @@
         <PackageReference Include="HidSharp" Version="2.1.0" />
         <PackageReference Include="Humanizer.Core" Version="2.14.1" />
         <PackageReference Include="JetBrains.Annotations" Version="2023.2.0" />
-        <PackageReference Include="LiteDB" Version="5.0.17" />
         <PackageReference Include="McMaster.NETCore.Plugins" Version="1.4.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
         <PackageReference Include="RGB.NET.Core" Version="$(RGBDotNetVersion)" />
+        <PackageReference Include="RGB.NET.Layout" Version="$(RGBDotNetVersion)" />
         <PackageReference Include="RGB.NET.Presets" Version="$(RGBDotNetVersion)" />
         <PackageReference Include="Serilog" Version="3.0.1" />
         <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
         <PackageReference Include="Serilog.Sinks.Debug" Version="2.0.0" />
         <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
         <PackageReference Include="SkiaSharp" Version="$(SkiaSharpVersion)" />
-        <PackageReference Include="System.Buffers" Version="4.5.1" />
-        <PackageReference Include="System.IO.FileSystem.AccessControl" Version="5.0.0" />
-        <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
-        <PackageReference Include="System.ValueTuple" Version="4.5.0" />
-        <PackageReference Include="Unosquare.Swan.Lite" Version="3.1.0" />
     </ItemGroup>
 
     <ItemGroup>
         <None Include="Resources/intro-profile.json" CopyToOutputDirectory="PreserveNewest" />
         <None Include="DefaultLayouts/**" CopyToOutputDirectory="PreserveNewest" />
-    </ItemGroup>
-
-    <ItemGroup>
-      <Reference Include="RGB.NET.Layout">
-        <HintPath>..\..\..\RGB.NET\bin\net7.0\RGB.NET.Layout.dll</HintPath>
-      </Reference>
     </ItemGroup>
 </Project>

--- a/src/Artemis.Storage/Artemis.Storage.csproj
+++ b/src/Artemis.Storage/Artemis.Storage.csproj
@@ -1,6 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-    <Import Project="..\Artemis.props" />
-    
     <PropertyGroup>
         <TargetFramework>net7.0</TargetFramework>
         <PreserveCompilationContext>false</PreserveCompilationContext>

--- a/src/Artemis.Storage/Artemis.Storage.csproj
+++ b/src/Artemis.Storage/Artemis.Storage.csproj
@@ -7,6 +7,6 @@
 
     <ItemGroup>
         <PackageReference Include="LiteDB" Version="5.0.17" />
-        <PackageReference Include="Serilog" Version="3.0.1" />
+        <PackageReference Include="Serilog" Version="3.1.1" />
     </ItemGroup>
 </Project>

--- a/src/Artemis.UI.Linux/Artemis.UI.Linux.csproj
+++ b/src/Artemis.UI.Linux/Artemis.UI.Linux.csproj
@@ -18,14 +18,6 @@
         <None Remove=".gitignore" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Avalonia" Version="$(AvaloniaVersion)" />
-        <PackageReference Include="Avalonia.Desktop" Version="$(AvaloniaVersion)" />
-        <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-        <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="$(AvaloniaVersion)" />
-        <PackageReference Include="Avalonia.ReactiveUI" Version="$(AvaloniaVersion)" />
-        <PackageReference Include="ReactiveUI" Version="19.5.1" />
-    </ItemGroup>
-    <ItemGroup>
         <ProjectReference Include="..\Artemis.Core\Artemis.Core.csproj" />
         <ProjectReference Include="..\Artemis.UI\Artemis.UI.csproj" />
     </ItemGroup>

--- a/src/Artemis.UI.Linux/Artemis.UI.Linux.csproj
+++ b/src/Artemis.UI.Linux/Artemis.UI.Linux.csproj
@@ -1,6 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-    <Import Project="..\Artemis.props" />
-    
     <PropertyGroup>
         <OutputType>WinExe</OutputType>
         <TargetFramework>net7.0</TargetFramework>

--- a/src/Artemis.UI.MacOS/Artemis.UI.MacOS.csproj
+++ b/src/Artemis.UI.MacOS/Artemis.UI.MacOS.csproj
@@ -17,14 +17,6 @@
         <None Remove=".gitignore" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Avalonia" Version="$(AvaloniaVersion)" />
-        <PackageReference Include="Avalonia.Desktop" Version="$(AvaloniaVersion)" />
-        <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-        <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="$(AvaloniaVersion)" />
-        <PackageReference Include="Avalonia.ReactiveUI" Version="$(AvaloniaVersion)" />
-        <PackageReference Include="ReactiveUI" Version="19.5.1" />
-    </ItemGroup>
-    <ItemGroup>
         <ProjectReference Include="..\Artemis.Core\Artemis.Core.csproj" />
         <ProjectReference Include="..\Artemis.UI\Artemis.UI.csproj" />
     </ItemGroup>

--- a/src/Artemis.UI.MacOS/Artemis.UI.MacOS.csproj
+++ b/src/Artemis.UI.MacOS/Artemis.UI.MacOS.csproj
@@ -1,6 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-    <Import Project="..\Artemis.props" />
-    
     <PropertyGroup>
         <OutputType>WinExe</OutputType>
         <TargetFramework>net7.0</TargetFramework>

--- a/src/Artemis.UI.Shared/Artemis.UI.Shared.csproj
+++ b/src/Artemis.UI.Shared/Artemis.UI.Shared.csproj
@@ -10,16 +10,16 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Avalonia" Version="11.0.5" />
+        <PackageReference Include="Avalonia" Version="11.0.6" />
         <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-        <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.0.5" />
-        <PackageReference Include="Avalonia.Controls.ItemsRepeater" Version="11.0.5" />
-        <PackageReference Include="Avalonia.ReactiveUI" Version="11.0.5" />
-        <PackageReference Include="Avalonia.Xaml.Behaviors" Version="11.0.2" />
-        <PackageReference Include="DynamicData" Version="8.0.2" />
-        <PackageReference Include="FluentAvaloniaUI" Version="2.0.4" />
-        <PackageReference Include="Material.Icons.Avalonia" Version="2.0.1" />
-        <PackageReference Include="ReactiveUI" Version="19.5.1" />
+        <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.0.6" />
+        <PackageReference Include="Avalonia.Controls.ItemsRepeater" Version="11.0.6" />
+        <PackageReference Include="Avalonia.ReactiveUI" Version="11.0.6" />
+        <PackageReference Include="Avalonia.Xaml.Behaviors" Version="11.0.6" />
+        <PackageReference Include="DynamicData" Version="8.3.27" />
+        <PackageReference Include="FluentAvaloniaUI" Version="2.0.5" />
+        <PackageReference Include="Material.Icons.Avalonia" Version="2.1.0" />
+        <PackageReference Include="ReactiveUI" Version="19.5.39" />
         <PackageReference Include="ReactiveUI.Validation" Version="3.1.7" />
     </ItemGroup>
     <ItemGroup>

--- a/src/Artemis.UI.Shared/Artemis.UI.Shared.csproj
+++ b/src/Artemis.UI.Shared/Artemis.UI.Shared.csproj
@@ -17,22 +17,17 @@
         <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="$(AvaloniaVersion)" />
         <PackageReference Include="Avalonia.Controls.ItemsRepeater" Version="$(AvaloniaVersion)" />
         <PackageReference Include="Avalonia.ReactiveUI" Version="$(AvaloniaVersion)" />
-        <PackageReference Include="Avalonia.Xaml.Behaviors" Version="$(AvaloniaBehavioursVersion)" />
+        <PackageReference Include="Avalonia.Xaml.Behaviors" Version="11.0.2" />
         <PackageReference Include="DynamicData" Version="8.0.2" />
-        <PackageReference Include="FluentAvaloniaUI" Version="$(FluentAvaloniaVersion)" />
+        <PackageReference Include="FluentAvaloniaUI" Version="2.0.4" />
         <PackageReference Include="Material.Icons.Avalonia" Version="2.0.1" />
         <PackageReference Include="ReactiveUI" Version="19.5.1" />
         <PackageReference Include="ReactiveUI.Validation" Version="3.1.7" />
-        <PackageReference Include="RGB.NET.Core" Version="$(RGBDotNetVersion)" />
-        <PackageReference Include="SkiaSharp" Version="$(SkiaSharpVersion)" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\Artemis.Core\Artemis.Core.csproj" />
     </ItemGroup>
     <ItemGroup>
-      <Reference Include="AsyncImageLoader.Avalonia">
-        <HintPath>..\..\..\..\Users\Robert\.nuget\packages\asyncimageloader.avalonia\3.2.1\lib\netstandard2.1\AsyncImageLoader.Avalonia.dll</HintPath>
-      </Reference>
       <Reference Include="RGB.NET.Layout">
         <HintPath>..\..\..\RGB.NET\bin\net7.0\RGB.NET.Layout.dll</HintPath>
       </Reference>

--- a/src/Artemis.UI.Shared/Artemis.UI.Shared.csproj
+++ b/src/Artemis.UI.Shared/Artemis.UI.Shared.csproj
@@ -1,6 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-    <Import Project="..\Artemis.props" />
-    
     <PropertyGroup>
         <OutputType>Library</OutputType>
         <TargetFramework>net7.0</TargetFramework>
@@ -12,11 +10,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Avalonia" Version="$(AvaloniaVersion)" />
+        <PackageReference Include="Avalonia" Version="11.0.5" />
         <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-        <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="$(AvaloniaVersion)" />
-        <PackageReference Include="Avalonia.Controls.ItemsRepeater" Version="$(AvaloniaVersion)" />
-        <PackageReference Include="Avalonia.ReactiveUI" Version="$(AvaloniaVersion)" />
+        <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.0.5" />
+        <PackageReference Include="Avalonia.Controls.ItemsRepeater" Version="11.0.5" />
+        <PackageReference Include="Avalonia.ReactiveUI" Version="11.0.5" />
         <PackageReference Include="Avalonia.Xaml.Behaviors" Version="11.0.2" />
         <PackageReference Include="DynamicData" Version="8.0.2" />
         <PackageReference Include="FluentAvaloniaUI" Version="2.0.4" />
@@ -26,10 +24,5 @@
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\Artemis.Core\Artemis.Core.csproj" />
-    </ItemGroup>
-    <ItemGroup>
-      <Reference Include="RGB.NET.Layout">
-        <HintPath>..\..\..\RGB.NET\bin\net7.0\RGB.NET.Layout.dll</HintPath>
-      </Reference>
     </ItemGroup>
 </Project>

--- a/src/Artemis.UI.Windows/Artemis.UI.Windows.csproj
+++ b/src/Artemis.UI.Windows/Artemis.UI.Windows.csproj
@@ -23,17 +23,11 @@
         </None>
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Avalonia" Version="$(AvaloniaVersion)" />
-        <PackageReference Include="Avalonia.Desktop" Version="$(AvaloniaVersion)" />
-        <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-        <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="$(AvaloniaVersion)" />
-        <PackageReference Include="Avalonia.ReactiveUI" Version="$(AvaloniaVersion)" />
         <PackageReference Include="Avalonia.Win32" Version="$(AvaloniaVersion)" />
         <PackageReference Include="Microsoft.Toolkit.Uwp.Notifications" Version="7.1.3" />
         <PackageReference Include="Microsoft.Win32" Version="2.0.1" />
         <PackageReference Include="Microsoft.Windows.Compatibility" Version="7.0.5" />
         <PackageReference Include="RawInput.Sharp" Version="0.1.1" />
-        <PackageReference Include="ReactiveUI" Version="19.5.1" />
         <PackageReference Include="SkiaSharp.Vulkan.SharpVk" Version="$(SkiaSharpVersion)" />
     </ItemGroup>
     <ItemGroup>

--- a/src/Artemis.UI.Windows/Artemis.UI.Windows.csproj
+++ b/src/Artemis.UI.Windows/Artemis.UI.Windows.csproj
@@ -21,12 +21,13 @@
         </None>
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Avalonia.Win32" Version="11.0.5" />
+        <PackageReference Include="Avalonia.Win32" Version="11.0.6" />
         <PackageReference Include="Microsoft.Toolkit.Uwp.Notifications" Version="7.1.3" />
         <PackageReference Include="Microsoft.Win32" Version="2.0.1" />
+        <!-- Note: Do NOT upgrade this compatibility package to 8.X before updating to net8, it WILL break -->
         <PackageReference Include="Microsoft.Windows.Compatibility" Version="7.0.5" />
-        <PackageReference Include="RawInput.Sharp" Version="0.1.1" />
-        <PackageReference Include="SkiaSharp.Vulkan.SharpVk" Version="$(SkiaSharpVersion)" />
+        <PackageReference Include="RawInput.Sharp" Version="0.1.3" />
+        <PackageReference Include="SkiaSharp.Vulkan.SharpVk" Version="2.88.7" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\Artemis.Core\Artemis.Core.csproj" />

--- a/src/Artemis.UI.Windows/Artemis.UI.Windows.csproj
+++ b/src/Artemis.UI.Windows/Artemis.UI.Windows.csproj
@@ -1,6 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-    <Import Project="..\Artemis.props" />
-    
     <PropertyGroup>
         <OutputType>WinExe</OutputType>
         <TargetFramework>net7.0-windows10.0.17763.0</TargetFramework>
@@ -23,7 +21,7 @@
         </None>
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Avalonia.Win32" Version="$(AvaloniaVersion)" />
+        <PackageReference Include="Avalonia.Win32" Version="11.0.5" />
         <PackageReference Include="Microsoft.Toolkit.Uwp.Notifications" Version="7.1.3" />
         <PackageReference Include="Microsoft.Win32" Version="2.0.1" />
         <PackageReference Include="Microsoft.Windows.Compatibility" Version="7.0.5" />

--- a/src/Artemis.UI/Artemis.UI.csproj
+++ b/src/Artemis.UI/Artemis.UI.csproj
@@ -19,43 +19,22 @@
 
     <ItemGroup>
         <PackageReference Include="AsyncImageLoader.Avalonia" Version="3.2.1" />
-        <PackageReference Include="Avalonia" Version="$(AvaloniaVersion)" />
         <PackageReference Include="Avalonia.AvaloniaEdit" Version="11.0.1" />
         <PackageReference Include="Avalonia.Controls.PanAndZoom" Version="11.0.0" />
         <PackageReference Include="Avalonia.Desktop" Version="$(AvaloniaVersion)" />
-        <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-        <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="$(AvaloniaVersion)" />
-        <PackageReference Include="Avalonia.Controls.ItemsRepeater" Version="$(AvaloniaVersion)" />
-        <PackageReference Include="Avalonia.ReactiveUI" Version="$(AvaloniaVersion)" />
-        <PackageReference Include="Avalonia.Xaml.Behaviors" Version="$(AvaloniaBehavioursVersion)" />
         <PackageReference Include="Avalonia.Skia.Lottie" Version="11.0.0" />
         <PackageReference Include="AvaloniaEdit.TextMate" Version="11.0.1" />
-        <PackageReference Include="DryIoc.dll" Version="5.4.2" />
-        <PackageReference Include="DynamicData" Version="8.0.2" />
-        <PackageReference Include="FluentAvaloniaUI" Version="$(FluentAvaloniaVersion)" />
-        <PackageReference Include="Flurl.Http" Version="3.2.4" />
         <PackageReference Include="Markdown.Avalonia.Tight" Version="11.0.2" />
-        <PackageReference Include="Material.Icons.Avalonia" Version="2.0.1" />
         <PackageReference Include="Octopus.Octodiff" Version="2.0.468" />
         <PackageReference Include="PropertyChanged.SourceGenerator" Version="1.0.8">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="ReactiveUI" Version="19.5.1" />
-        <PackageReference Include="ReactiveUI.Validation" Version="3.1.7" />
-        <PackageReference Include="RGB.NET.Core" Version="$(RGBDotNetVersion)" />
-        <PackageReference Include="SkiaSharp" Version="$(SkiaSharpVersion)" />
         <PackageReference Include="Splat.DryIoc" Version="14.7.1" />
         <PackageReference Include="TextMateSharp.Grammars" Version="1.0.56" />
     </ItemGroup>
 
     <ItemGroup>
         <AvaloniaResource Include="Assets\**" />
-    </ItemGroup>
-
-    <ItemGroup>
-      <Reference Include="RGB.NET.Layout">
-        <HintPath>..\..\..\RGB.NET\bin\net7.0\RGB.NET.Layout.dll</HintPath>
-      </Reference>
     </ItemGroup>
 </Project>

--- a/src/Artemis.UI/Artemis.UI.csproj
+++ b/src/Artemis.UI/Artemis.UI.csproj
@@ -1,6 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-    <Import Project="..\Artemis.props" />
-
     <PropertyGroup>
         <OutputType>Library</OutputType>
         <TargetFramework>net7.0</TargetFramework>
@@ -21,7 +19,7 @@
         <PackageReference Include="AsyncImageLoader.Avalonia" Version="3.2.1" />
         <PackageReference Include="Avalonia.AvaloniaEdit" Version="11.0.1" />
         <PackageReference Include="Avalonia.Controls.PanAndZoom" Version="11.0.0" />
-        <PackageReference Include="Avalonia.Desktop" Version="$(AvaloniaVersion)" />
+        <PackageReference Include="Avalonia.Desktop" Version="11.0.5" />
         <PackageReference Include="Avalonia.Skia.Lottie" Version="11.0.0" />
         <PackageReference Include="AvaloniaEdit.TextMate" Version="11.0.1" />
         <PackageReference Include="Markdown.Avalonia.Tight" Version="11.0.2" />

--- a/src/Artemis.UI/Artemis.UI.csproj
+++ b/src/Artemis.UI/Artemis.UI.csproj
@@ -17,18 +17,18 @@
 
     <ItemGroup>
         <PackageReference Include="AsyncImageLoader.Avalonia" Version="3.2.1" />
-        <PackageReference Include="Avalonia.AvaloniaEdit" Version="11.0.1" />
-        <PackageReference Include="Avalonia.Controls.PanAndZoom" Version="11.0.0" />
-        <PackageReference Include="Avalonia.Desktop" Version="11.0.5" />
+        <PackageReference Include="Avalonia.AvaloniaEdit" Version="11.0.6" />
+        <PackageReference Include="Avalonia.Controls.PanAndZoom" Version="11.0.0.2" />
+        <PackageReference Include="Avalonia.Desktop" Version="11.0.6" />
         <PackageReference Include="Avalonia.Skia.Lottie" Version="11.0.0" />
-        <PackageReference Include="AvaloniaEdit.TextMate" Version="11.0.1" />
+        <PackageReference Include="AvaloniaEdit.TextMate" Version="11.0.6" />
         <PackageReference Include="Markdown.Avalonia.Tight" Version="11.0.2" />
-        <PackageReference Include="Octopus.Octodiff" Version="2.0.468" />
-        <PackageReference Include="PropertyChanged.SourceGenerator" Version="1.0.8">
+        <PackageReference Include="Octopus.Octodiff" Version="2.0.544" />
+        <PackageReference Include="PropertyChanged.SourceGenerator" Version="1.1.0">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Splat.DryIoc" Version="14.7.1" />
+        <PackageReference Include="Splat.DryIoc" Version="14.8.12" />
         <PackageReference Include="TextMateSharp.Grammars" Version="1.0.56" />
     </ItemGroup>
 

--- a/src/Artemis.UI/Screens/Settings/Tabs/AboutTabView.axaml
+++ b/src/Artemis.UI/Screens/Settings/Tabs/AboutTabView.axaml
@@ -101,7 +101,7 @@
                             </Ellipse.Fill>
                         </Ellipse>
                         <TextBlock Grid.Row="0" Grid.Column="1" Padding="0">
-                            Diogo 'DrMeteor' Trindade
+                            Diogo Trindade
                         </TextBlock>
                         <TextBlock Classes="subtitle" Grid.Column="1" Grid.Row="1" Padding="0">
                             Main contributor
@@ -176,7 +176,6 @@
                             <TextBlock Classes="library-name">DryIoc</TextBlock>
                             <TextBlock Classes="library-name">FluentAvalonia</TextBlock>
                             <TextBlock Classes="library-name">EmbedIO</TextBlock>
-                            <TextBlock Classes="library-name">Furl.Http</TextBlock>
                             <TextBlock Classes="library-name">Humanizer</TextBlock>
                             <TextBlock Classes="library-name">LiteDB</TextBlock>
                             <TextBlock Classes="library-name">McMaster.NETCore.Plugins</TextBlock>
@@ -198,9 +197,6 @@
                             </controls:HyperlinkButton>
                             <controls:HyperlinkButton NavigateUri="https://unosquare.github.io/embedio/">
                                 https://unosquare.github.io/embedio/
-                            </controls:HyperlinkButton>
-                            <controls:HyperlinkButton NavigateUri="https://flurl.dev/">
-                                https://flurl.dev/
                             </controls:HyperlinkButton>
                             <controls:HyperlinkButton NavigateUri="https://github.com/Humanizr/Humanizer">
                                 https://github.com/Humanizr/Humanizer

--- a/src/Artemis.UI/Screens/Workshop/CurrentUser/CurrentUserViewModel.cs
+++ b/src/Artemis.UI/Screens/Workshop/CurrentUser/CurrentUserViewModel.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using System.Net.Http;
 using System.Reactive;
 using System.Reactive.Disposables;
 using System.Threading;
@@ -10,7 +11,6 @@ using Artemis.WebClient.Workshop;
 using Artemis.WebClient.Workshop.Services;
 using Avalonia.Media.Imaging;
 using FluentAvalonia.UI.Controls;
-using Flurl.Http;
 using PropertyChanged.SourceGenerator;
 using ReactiveUI;
 using Serilog;
@@ -21,6 +21,7 @@ public partial class CurrentUserViewModel : ActivatableViewModelBase
 {
     private readonly IAuthenticationService _authenticationService;
     private readonly ObservableAsPropertyHelper<bool> _isAnonymous;
+    private readonly HttpClient _httpClient;
     private readonly ILogger _logger;
     private readonly IWindowService _windowService;
     [Notify] private bool _allowLogout = true;
@@ -35,6 +36,7 @@ public partial class CurrentUserViewModel : ActivatableViewModelBase
         _logger = logger;
         _authenticationService = authenticationService;
         _windowService = windowService;
+        _httpClient = new HttpClient();
         Login = ReactiveCommand.CreateFromTask(ExecuteLogin);
 
         _isAnonymous = this.WhenAnyValue(vm => vm.Loading, vm => vm.Name, (l, n) => l || n == null).ToProperty(this, vm => vm.IsAnonymous);
@@ -106,7 +108,7 @@ public partial class CurrentUserViewModel : ActivatableViewModelBase
         try
         {
             Avatar?.Dispose();
-            Avatar = new Bitmap(await $"{WorkshopConstants.AUTHORITY_URL}/user/avatar/{userId}".GetStreamAsync());
+            Avatar = new Bitmap(await _httpClient.GetStreamAsync($"{WorkshopConstants.AUTHORITY_URL}/user/avatar/{userId}"));
         }
         catch (Exception)
         {

--- a/src/Artemis.VisualScripting/Artemis.VisualScripting.csproj
+++ b/src/Artemis.VisualScripting/Artemis.VisualScripting.csproj
@@ -9,14 +9,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Avalonia" Version="$(AvaloniaVersion)" />
-        <PackageReference Include="Avalonia.ReactiveUI" Version="$(AvaloniaVersion)" />
-        <PackageReference Include="Avalonia.Xaml.Behaviors" Version="$(AvaloniaBehavioursVersion)" />
-        <PackageReference Include="DryIoc.dll" Version="5.4.2" />
         <PackageReference Include="NoStringEvaluating" Version="2.5.2" />
-        <PackageReference Include="ReactiveUI" Version="19.5.1" />
-        <PackageReference Include="ReactiveUI.Validation" Version="3.1.7" />
-        <PackageReference Include="SkiaSharp" Version="$(SkiaSharpVersion)" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Artemis.VisualScripting/Artemis.VisualScripting.csproj
+++ b/src/Artemis.VisualScripting/Artemis.VisualScripting.csproj
@@ -1,6 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-    <Import Project="..\Artemis.props" />
-
     <PropertyGroup>
         <TargetFramework>net7.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>

--- a/src/Artemis.WebClient.Updating/Artemis.WebClient.Updating.csproj
+++ b/src/Artemis.WebClient.Updating/Artemis.WebClient.Updating.csproj
@@ -1,6 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-    <Import Project="..\Artemis.props" />
-
     <PropertyGroup>
         <TargetFramework>net7.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>

--- a/src/Artemis.WebClient.Updating/Artemis.WebClient.Updating.csproj
+++ b/src/Artemis.WebClient.Updating/Artemis.WebClient.Updating.csproj
@@ -9,7 +9,6 @@
     <ItemGroup>
       <PackageReference Include="DryIoc.dll" Version="5.4.2" />
       <PackageReference Include="DryIoc.Microsoft.DependencyInjection" Version="6.2.0" />
-      <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
       <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
       <PackageReference Include="StrawberryShake.Server" Version="13.5.1" />
     </ItemGroup>

--- a/src/Artemis.WebClient.Updating/Artemis.WebClient.Updating.csproj
+++ b/src/Artemis.WebClient.Updating/Artemis.WebClient.Updating.csproj
@@ -7,10 +7,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="DryIoc.dll" Version="5.4.2" />
+      <PackageReference Include="DryIoc.dll" Version="5.4.3" />
       <PackageReference Include="DryIoc.Microsoft.DependencyInjection" Version="6.2.0" />
       <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
-      <PackageReference Include="StrawberryShake.Server" Version="13.5.1" />
+      <PackageReference Include="StrawberryShake.Server" Version="13.8.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Artemis.WebClient.Workshop/Artemis.WebClient.Workshop.csproj
+++ b/src/Artemis.WebClient.Workshop/Artemis.WebClient.Workshop.csproj
@@ -1,6 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-    <Import Project="..\Artemis.props" />
-    
     <PropertyGroup>
         <TargetFramework>net7.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
@@ -11,12 +9,9 @@
     <ItemGroup>
       <PackageReference Include="DryIoc.Microsoft.DependencyInjection" Version="6.2.0" />
       <PackageReference Include="IdentityModel" Version="6.2.0" />
-      <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
       <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
-      <PackageReference Include="ReactiveUI" Version="19.5.1" />
       <PackageReference Include="StrawberryShake.Server" Version="13.7.0" />
       <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.0.3" />
-      <PackageReference Include="System.Reactive" Version="6.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Artemis.WebClient.Workshop/Artemis.WebClient.Workshop.csproj
+++ b/src/Artemis.WebClient.Workshop/Artemis.WebClient.Workshop.csproj
@@ -9,9 +9,9 @@
     <ItemGroup>
       <PackageReference Include="DryIoc.Microsoft.DependencyInjection" Version="6.2.0" />
       <PackageReference Include="IdentityModel" Version="6.2.0" />
-      <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
-      <PackageReference Include="StrawberryShake.Server" Version="13.7.0" />
-      <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.0.3" />
+      <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
+      <PackageReference Include="StrawberryShake.Server" Version="13.8.1" />
+      <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.2.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Artemis.WebClient.Workshop/Artemis.WebClient.Workshop.csproj
+++ b/src/Artemis.WebClient.Workshop/Artemis.WebClient.Workshop.csproj
@@ -9,7 +9,6 @@
     </PropertyGroup>
     
     <ItemGroup>
-      <PackageReference Include="DryIoc.dll" Version="5.4.2" />
       <PackageReference Include="DryIoc.Microsoft.DependencyInjection" Version="6.2.0" />
       <PackageReference Include="IdentityModel" Version="6.2.0" />
       <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
@@ -52,11 +51,5 @@
 
     <ItemGroup>
       <Folder Include="Handlers\" />
-    </ItemGroup>
-
-    <ItemGroup>
-      <Reference Include="RGB.NET.Layout">
-        <HintPath>..\..\..\RGB.NET\bin\net7.0\RGB.NET.Layout.dll</HintPath>
-      </Reference>
     </ItemGroup>
 </Project>

--- a/src/Artemis.props
+++ b/src/Artemis.props
@@ -1,9 +1,7 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
         <AvaloniaVersion>11.0.5</AvaloniaVersion>
-        <AvaloniaBehavioursVersion>11.0.2</AvaloniaBehavioursVersion>
-        <FluentAvaloniaVersion>2.0.4</FluentAvaloniaVersion>
-        <RGBDotNetVersion>2.0.0-prerelease.101</RGBDotNetVersion>
+        <RGBDotNetVersion>2.0.0-prerelease.125</RGBDotNetVersion>
         <SkiaSharpVersion>2.88.6</SkiaSharpVersion>
     </PropertyGroup>
 </Project>

--- a/src/Artemis.props
+++ b/src/Artemis.props
@@ -1,7 +1,0 @@
-<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <PropertyGroup>
-        <AvaloniaVersion>11.0.5</AvaloniaVersion>
-        <RGBDotNetVersion>2.0.0-prerelease.125</RGBDotNetVersion>
-        <SkiaSharpVersion>2.88.6</SkiaSharpVersion>
-    </PropertyGroup>
-</Project>

--- a/src/Artemis.sln
+++ b/src/Artemis.sln
@@ -25,7 +25,6 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Artemis.WebClient.Workshop"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{44482312-142F-44A4-992C-0AF0F26BAE54}"
 	ProjectSection(SolutionItems) = preProject
-		Artemis.props = Artemis.props
 		Artemis.sln.DotSettings = Artemis.sln.DotSettings
 		Artemis.sln.DotSettings.user = Artemis.sln.DotSettings.user
 	EndProjectSection


### PR DESCRIPTION
Makes it so each nuget package is referenced only once (except for the Updating package since that is isolated).

Should remove confusion when updating them as well.